### PR TITLE
fix: use statically linkable bin to ensure cli script is always available (NON-ISSUE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,6 @@ jobs:
       - name: lint
         run: pnpm lint
 
-      - name: run install again to correctly link bins (see CONTRIBUTING.md)
-        run: pnpm install
-
       - name: build
         run: pnpm build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,3 @@ pnpm install
 ```bash
 pnpm build
 ```
-
-### 5. install (AGAIN)
-
-After building the project, you need to install the dependencies again to ensure that all packages are linked correctly.
-
-```bash
-pnpm install
-```
-
-The first pnpm install can't link our local command-line tools because their files haven't been built yet. The second pnpm install allows us to correctly link the now-existing tool bin files.

--- a/packages/build/bin.js
+++ b/packages/build/bin.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+// stable entry point for CLI (so pnpm can symlink it even before build)
+import path from "path";
+import fs from "fs";
+
+const distPath = path.resolve(import.meta.dirname, "dist/cli.js");
+
+if (fs.existsSync(distPath)) {
+  await import(distPath);
+} else {
+  console.error("[svebcomponents]: cli tool not yet built.");
+  process.exit(1);
+}

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.4",
   "type": "module",
   "bin": {
-    "svebcomponents": "./dist/cli.js",
-    "prepare": "pnpm run build"
+    "svebcomponents": "./bin.js"
   },
   "scripts": {
     "dev": "tsc --watch",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.4",
   "type": "module",
   "bin": {
-    "svebcomponents": "./dist/cli.js"
+    "svebcomponents": "./dist/cli.js",
+    "prepare": "pnpm run build"
   },
   "scripts": {
     "dev": "tsc --watch",


### PR DESCRIPTION
add turborepo dependency to ensure `svebcomponent` cli is built
