### PR TITLE
fix: make tsdown build dependency

### DIFF
--- a/.changeset/true-jobs-design.md
+++ b/.changeset/true-jobs-design.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/build": patch
+---
+
+fix: ensure tsdown is a regular dependency

--- a/package.json
+++ b/package.json
@@ -27,10 +27,7 @@
     ]
   },
   "dependencies": {
-    "@changesets/cli": "catalog:",
-    "auto-options": "link:../../Library/pnpm/global/5/node_modules/packages/auto-options",
-    "build": "link:../../Library/pnpm/global/5/node_modules/packages/build",
-    "ssr": "link:../../Library/pnpm/global/5/node_modules/packages/ssr"
+    "@changesets/cli": "catalog:"
   },
   "overrides": {
     "@svebcomponents/build": "workspace:*",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -33,7 +33,6 @@
     "@svebcomponents/typescript-config": "workspace:*",
     "@types/node": "catalog:",
     "svelte": "catalog:",
-    "tsdown": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
     "rolldown": "catalog:"
@@ -45,6 +44,7 @@
     "tslib": "catalog:",
     "typescript": "catalog:",
     "unconfig": "catalog:",
+    "tsdown": "catalog:",
     "vitest": "catalog:"
   },
   "publishConfig": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -44,8 +44,7 @@
     "tslib": "catalog:",
     "typescript": "catalog:",
     "unconfig": "catalog:",
-    "tsdown": "catalog:",
-    "vitest": "catalog:"
+    "tsdown": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,9 +346,6 @@ importers:
       unconfig:
         specifier: 'catalog:'
         version: 7.3.2
-      vitest:
-        specifier: 'catalog:'
-        version: 3.2.4(@types/node@22.14.1)(@vitest/browser@3.2.4)(jiti@2.5.1)
     devDependencies:
       '@svebcomponents/eslint-config':
         specifier: workspace:*
@@ -371,6 +368,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 7.0.6(@types/node@22.14.1)(jiti@2.5.1)
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/node@22.14.1)(@vitest/browser@3.2.4)(jiti@2.5.1)
 
   packages/ssr:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,15 +116,6 @@ importers:
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.29.3
-      auto-options:
-        specifier: link:../../Library/pnpm/global/5/node_modules/packages/auto-options
-        version: link:../../Library/pnpm/global/5/node_modules/packages/auto-options
-      build:
-        specifier: link:../../Library/pnpm/global/5/node_modules/packages/build
-        version: link:../../Library/pnpm/global/5/node_modules/packages/build
-      ssr:
-        specifier: link:../../Library/pnpm/global/5/node_modules/packages/ssr
-        version: link:../../Library/pnpm/global/5/node_modules/packages/ssr
     devDependencies:
       eslint:
         specifier: 'catalog:'
@@ -343,6 +334,9 @@ importers:
       rollup-plugin-svelte:
         specifier: 'catalog:'
         version: 7.2.2(rollup@4.40.0)(svelte@5.28.2)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.15.12(publint@0.3.11)(typescript@5.8.3)
       tslib:
         specifier: 'catalog:'
         version: 2.8.1
@@ -374,9 +368,6 @@ importers:
       svelte:
         specifier: 'catalog:'
         version: 5.28.2
-      tsdown:
-        specifier: 'catalog:'
-        version: 0.15.12(publint@0.3.11)(typescript@5.8.3)
       vite:
         specifier: 'catalog:'
         version: 7.0.6(@types/node@22.14.1)(jiti@2.5.1)


### PR DESCRIPTION
tsdown is required to run the actual build on the client, so we make it a dependency
