### PR TITLE
test: ensure end-user provided content is escaped

### DIFF
--- a/e2e/ssr/test/server/SecurityComponent.svelte
+++ b/e2e/ssr/test/server/SecurityComponent.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  // import & register web component
+  import "../../dist/client/index.js";
+
+  interface Props {
+    attributePayload?: string;
+    content: string;
+    title: string;
+  }
+
+  let { title, attributePayload = title, content }: Props = $props();
+</script>
+
+<simple-component {title} data-test={attributePayload}>
+  {content}
+</simple-component>

--- a/e2e/ssr/test/server/render.test.ts
+++ b/e2e/ssr/test/server/render.test.ts
@@ -5,6 +5,7 @@ import { test, expect } from "vitest";
 import "../../dist/client/index.js";
 import SimpleComponentRenderer from "../../dist/server/ssr.js";
 
+import SecurityComponent from "./SecurityComponent.svelte";
 import SsrComponent from "./SsrComponent.svelte";
 
 const expectedRenderResult = {
@@ -23,4 +24,52 @@ test("rendering svelte", () => {
     },
   });
   expect(res).toStrictEqual(expectedRenderResult);
+});
+
+test("escapes untrusted values rendered through shadow props", () => {
+  ElementRendererRegistry.set("simple-component", SimpleComponentRenderer);
+
+  const payload = `"><img src=x onerror=alert(1)>`;
+  const res = render(SecurityComponent, {
+    props: {
+      title: payload,
+      content: "safe light dom",
+    },
+  });
+
+  expect(res.html).not.toContain("<img");
+  expect(res.html).toContain("&lt;img src=x onerror=alert(1)>");
+});
+
+test("escapes untrusted values rendered through light DOM children", () => {
+  ElementRendererRegistry.set("simple-component", SimpleComponentRenderer);
+
+  const payload = `<script>alert("xss")</script>`;
+  const res = render(SecurityComponent, {
+    props: {
+      title: "safe title",
+      content: payload,
+    },
+  });
+
+  expect(res.html).not.toContain("<script>");
+  expect(res.html).toContain('&lt;script>alert("xss")&lt;/script>');
+});
+
+test("does not turn untrusted host attribute values into markup", () => {
+  ElementRendererRegistry.set("simple-component", SimpleComponentRenderer);
+
+  const payload = `"><img src=x onerror=alert(1)>`;
+  const res = render(SecurityComponent, {
+    props: {
+      attributePayload: payload,
+      title: "safe title",
+      content: "safe light dom",
+    },
+  });
+
+  expect(res.html).not.toContain("<img");
+  if (res.html.includes("data-test=")) {
+    expect(res.html).toContain("&lt;img src=x onerror=alert(1)>");
+  }
 });


### PR DESCRIPTION
## Summary
- add an SSR security fixture for hostile custom element inputs
- cover escaped shadow props and light DOM children
- add a future-facing host attribute guard so emitted attributes cannot become markup

## Validation
- pnpm --filter @svebcomponents/e2e.ssr test