### PR TITLE
fix: add package repository metadata

### DIFF
--- a/packages/auto-options/package.json
+++ b/packages/auto-options/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@svebcomponents/auto-options",
   "version": "0.0.4",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/svebcomponents/svebcomponents",
+    "directory": "packages/auto-options"
+  },
   "scripts": {
     "build": "rm -rf dist && tsc",
     "check": "tsc --noEmit",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@svebcomponents/build",
   "version": "0.0.8",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/svebcomponents/svebcomponents",
+    "directory": "packages/build"
+  },
   "type": "module",
   "bin": {
     "svebcomponents": "./bin.js"

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@svebcomponents/ssr",
   "version": "0.0.7",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/svebcomponents/svebcomponents",
+    "directory": "packages/ssr"
+  },
   "scripts": {
     "build": "svelte-package && publint",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@svebcomponents/utils",
   "version": "0.0.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/svebcomponents/svebcomponents",
+    "directory": "packages/utils"
+  },
   "type": "module",
   "scripts": {
     "dev": "tsc --watch",


### PR DESCRIPTION
## Summary
- add repository metadata to the four published package manifests
- set repository.url to the URL npm expected from the trusted-publishing provenance check
- include each package directory for monorepo metadata clarity

## Verification
- Parsed all updated package.json files and verified repository.url
- pnpm check