### PR TITLE
test: add e2e for svelte conditional exports

### DIFF
--- a/apps/docs/src/content/docs/core-concepts/build.mdx
+++ b/apps/docs/src/content/docs/core-concepts/build.mdx
@@ -82,11 +82,13 @@ select `dist/client-svelte/index.js` and share the host application's Svelte
 runtime. Other consumers select the standalone `default` build.
 
 :::caution
-The Svelte-aware build relies on Svelte runtime internals. Those internals do
-not guarantee compatibility across patch or minor releases. Only use this
-optimization when the component package and consuming application are built
-with the same Svelte version. Keep the standalone `default` export as the safe
-fallback for other consumers.
+The Svelte-aware build relies on Svelte runtime internals. Those internals are
+versioned with Svelte and its compiler, but they are not a semver-stable public
+API: a patch or minor compiler release can change the runtime contract in ways
+that break previously compiled output. Only use this optimization when the
+component package and consuming application are built with the same Svelte
+version. Keep the standalone `default` export as the safe fallback for other
+consumers.
 :::
 
 Every matching export becomes a component entrypoint, so a package can expose

--- a/e2e/conditional-export-host/package.json
+++ b/e2e/conditional-export-host/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@svebcomponents/e2e.conditional-export-host",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "build": "svebcomponents",
+    "test": "vitest run"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/client/index.d.ts",
+      "svelte": "./dist/client-svelte/index.js",
+      "default": "./dist/client/index.js"
+    }
+  },
+  "devDependencies": {
+    "svelte": "catalog:",
+    "@sveltejs/vite-plugin-svelte": "catalog:",
+    "@svebcomponents/build": "workspace:*",
+    "@svebcomponents/typescript-config": "workspace:*",
+    "@vitest/browser": "catalog:",
+    "vitest": "catalog:",
+    "playwright": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/e2e/conditional-export-host/src/Component.svelte
+++ b/e2e/conditional-export-host/src/Component.svelte
@@ -1,0 +1,21 @@
+<svelte:options customElement={{
+  tag: 'conditional-host-widget',
+  props: {
+    count: {
+      type: 'Number',
+    },
+    enabled: {
+      type: 'Boolean',
+    }
+  }
+}} />
+
+<script lang="ts">
+  let { title, count = 0, enabled = true } = $props();
+</script>
+
+<section>
+  <h1>{title}</h1>
+  <p id="count">Count: {typeof count}-{count}</p>
+  <p id="enabled">Enabled: {typeof enabled}-{enabled}</p>
+</section>

--- a/e2e/conditional-export-host/src/index.ts
+++ b/e2e/conditional-export-host/src/index.ts
@@ -1,0 +1,7 @@
+import Component from "./Component.svelte";
+
+if (!customElements.get("conditional-host-widget") && Component.element) {
+  customElements.define("conditional-host-widget", Component.element);
+}
+
+export default Component;

--- a/e2e/conditional-export-host/test/client/Host.svelte
+++ b/e2e/conditional-export-host/test/client/Host.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import "@svebcomponents/e2e.conditional-export-host";
+
+  let count = $state(2);
+  let enabled = $state(true);
+</script>
+
+<button id="increment" onclick={() => count += 1}>Increment</button>
+<button id="toggle" onclick={() => enabled = !enabled}>Toggle</button>
+<p id="host-count">Host count: {count}</p>
+
+<conditional-host-widget
+  title="Shared Runtime"
+  count={count}
+  enabled={enabled}
+></conditional-host-widget>

--- a/e2e/conditional-export-host/test/client/component.test.ts
+++ b/e2e/conditional-export-host/test/client/component.test.ts
@@ -1,0 +1,61 @@
+import { mount, tick, unmount } from "svelte";
+import { assert, expect, test } from "vitest";
+import resolvedExportPath from "virtual:resolved-conditional-export";
+
+import Host from "./Host.svelte";
+
+const waitForCustomElementRender = async () => {
+  await customElements.whenDefined("conditional-host-widget");
+  await tick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const expectCustomElementState = (
+  element: Element,
+  count: number,
+  enabled: boolean,
+) => {
+  const shadowRoot = element.shadowRoot;
+  expect(shadowRoot).not.toBeNull();
+  assert(shadowRoot);
+
+  expect(shadowRoot.querySelector("h1")?.textContent).toBe("Shared Runtime");
+  expect(shadowRoot.querySelector("#count")?.textContent).toBe(
+    `Count: number-${count}`,
+  );
+  expect(shadowRoot.querySelector("#enabled")?.textContent).toBe(
+    `Enabled: boolean-${enabled}`,
+  );
+};
+
+test("Svelte-aware conditional export works inside a Svelte host runtime", async () => {
+  expect(resolvedExportPath).toMatch(/dist\/client-svelte\/index\.js$/);
+
+  const target = document.createElement("main");
+  document.body.replaceChildren(target);
+
+  const host = mount(Host, { target });
+  await waitForCustomElementRender();
+
+  const hostCount = target.querySelector("#host-count");
+  const customElement = target.querySelector("conditional-host-widget");
+  const increment = target.querySelector<HTMLButtonElement>("#increment");
+  const toggle = target.querySelector<HTMLButtonElement>("#toggle");
+
+  assert(hostCount);
+  assert(customElement);
+  assert(increment);
+  assert(toggle);
+
+  expect(hostCount.textContent).toBe("Host count: 2");
+  expectCustomElementState(customElement, 2, true);
+
+  increment.click();
+  toggle.click();
+  await waitForCustomElementRender();
+
+  expect(hostCount.textContent).toBe("Host count: 3");
+  expectCustomElementState(customElement, 3, false);
+
+  unmount(host);
+});

--- a/e2e/conditional-export-host/test/client/setup.ts
+++ b/e2e/conditional-export-host/test/client/setup.ts
@@ -1,0 +1,2 @@
+/// <reference types="@vitest/browser/matchers" />
+/// <reference types="@vitest/browser/providers/playwright" />

--- a/e2e/conditional-export-host/test/client/vite-env.d.ts
+++ b/e2e/conditional-export-host/test/client/vite-env.d.ts
@@ -1,0 +1,5 @@
+declare module "virtual:resolved-conditional-export" {
+  const resolvedExportPath: string | null;
+
+  export default resolvedExportPath;
+}

--- a/e2e/conditional-export-host/test/conditionalExportResolutionTest.ts
+++ b/e2e/conditional-export-host/test/conditionalExportResolutionTest.ts
@@ -1,0 +1,29 @@
+import type { Plugin } from "vite";
+
+const packageName = "@svebcomponents/e2e.conditional-export-host";
+const resolvedExportModuleId = "virtual:resolved-conditional-export";
+
+export const conditionalExportResolutionTest = (): Plugin => ({
+  name: "conditional-export-resolution-test",
+  resolveId(id) {
+    if (id === resolvedExportModuleId) {
+      return `\0${resolvedExportModuleId}`;
+    }
+  },
+  async load(id) {
+    if (id !== `\0${resolvedExportModuleId}`) {
+      return;
+    }
+
+    /*
+     * Rendering alone could pass through the bundled default export. Ask Vite
+     * which package entry it resolves in the Svelte host so the browser test can
+     * prove the `svelte` condition is actually selected.
+     */
+    const resolvedPackage = await this.resolve(packageName, undefined, {
+      skipSelf: true,
+    });
+
+    return `export default ${JSON.stringify(resolvedPackage?.id ?? null)};`;
+  },
+});

--- a/e2e/conditional-export-host/tsconfig.json
+++ b/e2e/conditional-export-host/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "@svebcomponents/typescript-config/node",
+    "include": [
+        "src",
+        "test",
+        "vitest.config.ts"
+    ]
+}

--- a/e2e/conditional-export-host/vitest.config.ts
+++ b/e2e/conditional-export-host/vitest.config.ts
@@ -1,0 +1,23 @@
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { defineConfig } from "vitest/config";
+
+import { conditionalExportResolutionTest } from "./test/conditionalExportResolutionTest.js";
+
+export default defineConfig({
+  plugins: [conditionalExportResolutionTest(), svelte()],
+  test: {
+    setupFiles: ["test/client/setup.ts"],
+    include: ["test/client/component.test.ts"],
+    browser: {
+      screenshotFailures: false,
+      enabled: true,
+      instances: [
+        {
+          browser: "chromium",
+        },
+      ],
+      headless: true,
+      provider: "playwright",
+    },
+  },
+});

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -67,11 +67,13 @@ reuse the host application's runtime.
 Other consumers fall back to `default`, which includes the Svelte runtime and
 can run outside Svelte applications.
 
-This optimization comes with a compatibility risk: the Svelte runtime is an
-implementation detail and does not guarantee compatibility even between patch
-or minor versions. The component package and host application should be built
-with the same Svelte version when using the `svelte` export. Consumers that
-cannot guarantee that should use the standalone `default` build.
+This optimization comes with a compatibility risk: the Svelte runtime internals
+are versioned with Svelte and its compiler, but they are not a semver-stable
+public API. A patch or minor compiler release can change the runtime contract in
+ways that break previously compiled output. The component package and host
+application should be built with the same Svelte version when using the `svelte`
+export. Consumers that cannot guarantee that should use the standalone
+`default` build.
 
 ## Multiple Components
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,33 @@ importers:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.13)(@types/node@24.13.2)(@vitest/browser@3.2.4)(jiti@2.5.1)(yaml@2.9.0)
 
+  e2e/conditional-export-host:
+    devDependencies:
+      '@svebcomponents/build':
+        specifier: workspace:*
+        version: link:../../packages/build
+      '@svebcomponents/typescript-config':
+        specifier: workspace:*
+        version: link:../../configs/typescript-config
+      '@sveltejs/vite-plugin-svelte':
+        specifier: 'catalog:'
+        version: 6.1.0(svelte@5.28.2)(vite@7.0.6(@types/node@24.13.2)(jiti@2.5.1)(yaml@2.9.0))
+      '@vitest/browser':
+        specifier: 'catalog:'
+        version: 3.2.4(playwright@1.45.0)(vite@7.0.6(@types/node@24.13.2)(jiti@2.5.1)(yaml@2.9.0))(vitest@3.2.4)
+      playwright:
+        specifier: 'catalog:'
+        version: 1.45.0
+      svelte:
+        specifier: 'catalog:'
+        version: 5.28.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.13.2)(@vitest/browser@3.2.4)(jiti@2.5.1)(yaml@2.9.0)
+
   e2e/ssr:
     devDependencies:
       '@svebcomponents/auto-options':


### PR DESCRIPTION
## Summary

- Add an e2e fixture that builds a custom element package with both `default` and `svelte` conditional exports.
- Exercise the package from a Svelte host component through Vite/Svelte resolution, asserting the `svelte` condition resolves to `dist/client-svelte/index.js`.
- Verify the host component and custom element update together while sharing the host Svelte runtime.
- Clarify docs wording that Svelte runtime internals are versioned with Svelte/compiler, but are not a semver-stable public API.

## Validation

- `pnpm --filter @svebcomponents/e2e.conditional-export-host... build`
- `pnpm --filter @svebcomponents/e2e.conditional-export-host test`