### PR TITLE
feat: implement ssr attribute rendering

### DIFF
--- a/.changeset/ssr-attribute-rendering.md
+++ b/.changeset/ssr-attribute-rendering.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Render SSR host attributes for Svelte custom elements, including reflected props, while using Svelte's SSR attribute serializer for escaped attribute values and boolean attributes.

--- a/e2e/ssr/test/server/render.test.ts
+++ b/e2e/ssr/test/server/render.test.ts
@@ -10,8 +10,8 @@ import SsrComponent from "./SsrComponent.svelte";
 
 const expectedRenderResult = {
   head: "",
-  body: '<!--[--><!--[!--><p>server</p> <!----><simple-component><template shadowrootmode="open"><!--164jyg1--><!--[--><div><h1>SSR Test</h1> <p id="count">Count: number-5</p> <p id="enabled">Enabled: boolean-true</p></div><!--]--><!----></template> <!----><!----></simple-component><!----><!--]--><!--]-->',
-  html: '<!--[--><!--[!--><p>server</p> <!----><simple-component><template shadowrootmode="open"><!--164jyg1--><!--[--><div><h1>SSR Test</h1> <p id="count">Count: number-5</p> <p id="enabled">Enabled: boolean-true</p></div><!--]--><!----></template> <!----><!----></simple-component><!----><!--]--><!--]-->',
+  body: '<!--[--><!--[!--><p>server</p> <!--1mdqziy--><simple-component title="SSR Test" count="5" enabled><!----> <template shadowrootmode="open"><!--164jyg1--><!--[--><div><h1>SSR Test</h1> <p id="count">Count: number-5</p> <p id="enabled">Enabled: boolean-true</p></div><!--]--><!----></template> <!----> <!--1llhvfc--></simple-component><!----><!--]--><!--]-->',
+  html: '<!--[--><!--[!--><p>server</p> <!--1mdqziy--><simple-component title="SSR Test" count="5" enabled><!----> <template shadowrootmode="open"><!--164jyg1--><!--[--><div><h1>SSR Test</h1> <p id="count">Count: number-5</p> <p id="enabled">Enabled: boolean-true</p></div><!--]--><!----></template> <!----> <!--1llhvfc--></simple-component><!----><!--]--><!--]-->',
 };
 
 test("rendering svelte", () => {
@@ -69,7 +69,9 @@ test("does not turn untrusted host attribute values into markup", () => {
   });
 
   expect(res.html).not.toContain("<img");
-  if (res.html.includes("data-test=")) {
-    expect(res.html).toContain("&lt;img src=x onerror=alert(1)>");
-  }
+  // Confirms the hostile attribute payload is emitted as escaped attribute
+  // content, not parsed as markup or as additional attributes.
+  expect(res.html).toContain(
+    'data-test="&quot;>&lt;img src=x onerror=alert(1)>"',
+  );
 });

--- a/packages/ssr/src/lib/runtime/html.ts
+++ b/packages/ssr/src/lib/runtime/html.ts
@@ -1,0 +1,95 @@
+// eslint-disable-next-line svelte/no-svelte-internal -- Reuse Svelte's SSR attribute serializer instead of maintaining our own escaping rules.
+import { attr } from "svelte/internal/server";
+
+export const SvelteCustomElementPropType = {
+  Array: "Array",
+  Boolean: "Boolean",
+  Number: "Number",
+  Object: "Object",
+  String: "String",
+} as const;
+
+export type SvelteCustomElementPropType =
+  (typeof SvelteCustomElementPropType)[keyof typeof SvelteCustomElementPropType];
+
+export interface SvelteCustomElementPropDefinition {
+  attribute?: string;
+  reflect?: boolean;
+  type?: SvelteCustomElementPropType;
+}
+
+const invalidAttributeNameCharsRegex = /[\s"'>/=]/;
+
+/**
+ * ASCII subset of the HTML spec's PotentialCustomElementName grammar.
+ * The wrapper only receives tag names produced from Svelte source, but this
+ * keeps the raw SSR opening/closing tags from ever accepting tag-shaped input.
+ *
+ * @see https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+ */
+export const isValidCustomElementTagName = (tagName: string) =>
+  /^[a-z][.0-9_a-z-]*-[.0-9_a-z-]*$/.test(tagName);
+
+/**
+ * Reject characters that cannot appear in HTML attribute names.
+ *
+ * We still delegate value escaping/formatting to Svelte's `attr` helper, but
+ * Svelte assumes compiler-produced attribute names. Since this renderer can
+ * receive names from runtime custom-element inputs, we validate names before
+ * passing them to Svelte's serializer.
+ *
+ * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+ */
+const isValidAttributeName = (name: string) =>
+  name.length > 0 &&
+  !invalidAttributeNameCharsRegex.test(name) &&
+  !Array.from(name).some((char) => {
+    const charCode = char.charCodeAt(0);
+    return charCode <= 0x1f || charCode === 0x7f;
+  });
+
+/**
+ * Serialize one SSR host attribute using Svelte's own attribute helper for
+ * value escaping and boolean attribute formatting.
+ */
+export const renderSsrAttribute = (name: string, value: string) => {
+  if (!isValidAttributeName(name)) {
+    throw new Error(`Invalid SSR attribute name: ${name}`);
+  }
+
+  // Svelte's attr helper signature is attr(name, value, is_boolean). Passing
+  // `true` with `is_boolean=true` emits a bare boolean attribute, e.g. ` enabled`.
+  return value === "" ? attr(name, true, true) : attr(name, value);
+};
+
+/**
+ * Mirrors Svelte's generated custom-element prop-to-attribute conversion.
+ * Svelte stores this metadata on the generated element instance as `$$p_d`.
+ */
+export const propValueToAttributeValue = (
+  value: unknown,
+  propDefinition: SvelteCustomElementPropDefinition,
+): string | null => {
+  if (
+    propDefinition.type === SvelteCustomElementPropType.Boolean &&
+    typeof value !== "boolean"
+  ) {
+    value = value != null;
+  }
+
+  if (value == null) {
+    return null;
+  }
+
+  switch (propDefinition.type) {
+    case SvelteCustomElementPropType.Array:
+    case SvelteCustomElementPropType.Object:
+      return JSON.stringify(value);
+    case SvelteCustomElementPropType.Boolean:
+      return value ? "" : null;
+    case SvelteCustomElementPropType.Number:
+      return String(value);
+    default:
+      return String(value);
+  }
+};

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
@@ -10,6 +10,7 @@ import {
 import { SvelteCustomElementRenderer } from "./svelteCustomElementRenderer";
 import { render } from "svelte/server";
 import type { RenderInfo } from "@lit-labs/ssr";
+import { SvelteCustomElementPropType } from "./html";
 
 // Mock svelte/server
 vi.mock("svelte/server", () => ({
@@ -34,6 +35,7 @@ describe("SvelteCustomElementRenderer", () => {
       attributes: {},
       attributeChangedCallback: vi.fn(),
       $$d: {},
+      $$p_d: {},
       $$c: mockSvelteComponent,
     }));
 
@@ -69,6 +71,7 @@ describe("SvelteCustomElementRenderer", () => {
       attributes: {},
       attributeChangedCallback: vi.fn(),
       $$d: {},
+      $$p_d: {},
     };
     mockClientElementCtor.mockReturnValue(mockElement);
 
@@ -92,6 +95,7 @@ describe("SvelteCustomElementRenderer", () => {
       attributes: {},
       attributeChangedCallback: vi.fn(),
       $$d: {},
+      $$p_d: {},
     };
     mockClientElementCtor.mockReturnValue(mockElement);
 
@@ -111,12 +115,10 @@ describe("SvelteCustomElementRenderer", () => {
 
   test("renders attributes correctly", () => {
     const mockElement = {
-      attributes: {
-        "data-test": "value1",
-        "aria-label": "value2",
-      },
+      attributes: {},
       attributeChangedCallback: vi.fn(),
       $$d: {},
+      $$p_d: {},
     };
     mockClientElementCtor.mockReturnValue(mockElement);
 
@@ -126,19 +128,100 @@ describe("SvelteCustomElementRenderer", () => {
       tagName,
     );
 
+    renderer.setAttribute("data-test", "value1");
+    renderer.setAttribute("aria-label", "value2");
     const attributes = Array.from(renderer.renderAttributes());
 
     expect(attributes).toContain(' data-test="value1"');
     expect(attributes).toContain(' aria-label="value2"');
   });
 
-  // TODO: test if attributes are escaped correctly?
+  test("escapes attribute values", () => {
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: {},
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    renderer.setAttribute("data-test", `"><img src=x onerror=alert('xss')>`);
+    const attributes = Array.from(renderer.renderAttributes());
+
+    expect(attributes).toContain(
+      ` data-test="&quot;>&lt;img src=x onerror=alert('xss')>"`,
+    );
+  });
+
+  test("rejects invalid attribute names", () => {
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: {},
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    renderer.setAttribute(`data-test" onclick="alert(1)`, "value");
+
+    expect(() => Array.from(renderer.renderAttributes())).toThrow(
+      'Invalid SSR attribute name: data-test" onclick="alert(1)',
+    );
+  });
+
+  test("reflects configured properties to attributes", () => {
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: {},
+      $$p_d: {
+        enabled: {
+          attribute: "enabled",
+          reflect: true,
+          type: SvelteCustomElementPropType.Boolean,
+        },
+        count: {
+          attribute: "count",
+          reflect: true,
+          type: SvelteCustomElementPropType.Number,
+        },
+      },
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    renderer.setProperty("enabled", true);
+    renderer.setProperty("count", 5);
+
+    expect(Array.from(renderer.renderAttributes())).toStrictEqual([
+      " enabled",
+      ' count="5"',
+    ]);
+  });
 
   test("sets properties to data property", () => {
     const mockElement = {
       attributes: {},
       attributeChangedCallback: vi.fn(),
       $$d: {},
+      $$p_d: {},
     };
     mockClientElementCtor.mockReturnValue(mockElement);
 
@@ -160,6 +243,7 @@ describe("SvelteCustomElementRenderer", () => {
       attributes: {},
       attributeChangedCallback: vi.fn(),
       $$d: { prop1: "value1", prop2: "value2" },
+      $$p_d: {},
     };
     mockClientElementCtor.mockReturnValue(mockElement);
 
@@ -192,6 +276,7 @@ describe("SvelteCustomElementRenderer", () => {
       attributes: {},
       attributeChangedCallback: vi.fn(),
       $$d: {},
+      $$p_d: {},
     };
     mockClientElementCtor.mockReturnValue(mockElement);
 

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
@@ -6,6 +6,12 @@ import {
 import type { Component } from "svelte";
 import { render } from "svelte/server";
 
+import {
+  propValueToAttributeValue,
+  renderSsrAttribute,
+  type SvelteCustomElementPropDefinition,
+} from "./html.js";
+
 export interface SvelteClientCustomElement {
   new (): Omit<SvelteClientCustomElement, "new">;
   attributes: Record<string, string>;
@@ -15,6 +21,11 @@ export interface SvelteClientCustomElement {
     newValue: string,
   ) => void;
   ["$$d"]: Record<string, unknown>;
+  /**
+   * Svelte's generated custom-element prop definition map. It tells us which
+   * component props should reflect to host attributes during SSR.
+   */
+  ["$$p_d"]: Record<string, SvelteCustomElementPropDefinition>;
   ["$$c"]: Component;
 }
 
@@ -23,6 +34,7 @@ export class SvelteCustomElementRenderer
   extends ElementRenderer
   implements ElementRenderer
 {
+  private readonly ssrAttributes = new Map<string, string>();
   private readonly svelteClientCustomElement: SvelteClientCustomElement;
 
   constructor(
@@ -42,18 +54,20 @@ export class SvelteCustomElementRenderer
       // maybe do something to reflect the prop to the attributes, perhaps 'this.$$me' does this out of the box for us?
       return;
     }
+    name = name.toLowerCase();
+    this.ssrAttributes.set(name, value);
     this.svelteClientCustomElement.attributeChangedCallback(name, value, value);
   }
 
   override *renderAttributes(): RenderResult {
-    const attributes = this.svelteClientCustomElement.attributes;
-    for (const [name, value] of Object.entries(attributes)) {
-      yield ` ${name}="${value}"`;
+    for (const [name, value] of this.ssrAttributes) {
+      yield renderSsrAttribute(name, value);
     }
   }
 
   override setProperty(name: string, value: unknown) {
     this.svelteClientCustomElement.$$d[name] = value;
+    this.reflectPropertyToAttribute(name, value);
   }
 
   override *renderShadow(_renderInfo: RenderInfo): RenderResult | undefined {
@@ -62,5 +76,22 @@ export class SvelteCustomElementRenderer
     });
     yield head;
     yield body;
+  }
+
+  private reflectPropertyToAttribute(name: string, value: unknown) {
+    const propDefinition = this.svelteClientCustomElement.$$p_d[name];
+    if (!propDefinition?.reflect) {
+      return;
+    }
+
+    // This mirrors Svelte's default observed attribute name when no explicit
+    // attribute is configured for a custom-element prop.
+    const attributeName = propDefinition.attribute ?? name.toLowerCase();
+    const attributeValue = propValueToAttributeValue(value, propDefinition);
+    if (attributeValue == null) {
+      this.ssrAttributes.delete(attributeName);
+      return;
+    }
+    this.ssrAttributes.set(attributeName, attributeValue);
   }
 }

--- a/packages/ssr/src/lib/svelte-internal.d.ts
+++ b/packages/ssr/src/lib/svelte-internal.d.ts
@@ -1,0 +1,3 @@
+declare module "svelte/internal/server" {
+  export function attr<V>(name: string, value: V, is_boolean?: boolean): string;
+}

--- a/packages/ssr/src/lib/vite/Server.svelte
+++ b/packages/ssr/src/lib/vite/Server.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
-  import { isKebabCase, camelizeKebabCase, TODO } from "@svebcomponents/utils";
+  import { isKebabCase, camelizeKebabCase } from "@svebcomponents/utils";
   import { collectResultSync } from "@lit-labs/ssr/lib/render-result.js";
 
+  import { isValidCustomElementTagName } from "../runtime/html.js";
   import { ElementRendererRegistry } from "../runtime/rendererRegistry.js";
 
   interface WebComponentWrapperProps {
@@ -16,6 +17,10 @@
     _tagName: tag,
     ...props
   }: WebComponentWrapperProps = $props();
+
+  if (!isValidCustomElementTagName(tag)) {
+    throw new Error(`Invalid custom element tag name: ${tag}`);
+  }
 
   // get the custom element constructor
   const ctor = customElements.get(tag);
@@ -45,20 +50,21 @@
   );
   if (!shadowStream) throw new Error(`Shadow stream for ${tag} not found`);
   const shadow = collectResultSync(shadowStream);
-  // TODO: attributes seem not to be rendered
-  // Attributes should probably be escaped?
   const attributes = collectResultSync(
     customElementRenderer.renderAttributes(),
   );
-  TODO("implement attribute rendering", attributes);
+  const openTag = `<${tag}${attributes}>`;
+  const closeTag = `</${tag}>`;
 </script>
 
 <p>server</p>
 
-<svelte:element this={tag}>
-  <template shadowrootmode="open">
-    <!-- eslint-disable-next-line -- it is the ElementRenderer's responsibility to ensure everything is properly sanitized -->
-    {@html shadow}
-  </template>
-  {@render children?.()}
-</svelte:element>
+<!-- eslint-disable-next-line svelte/no-at-html-tags -- tag name is validated above and attributes are escaped by the renderer -->
+{@html openTag}
+<template shadowrootmode="open">
+  <!-- eslint-disable-next-line -- it is the ElementRenderer's responsibility to ensure everything is properly sanitized -->
+  {@html shadow}
+</template>
+{@render children?.()}
+<!-- eslint-disable-next-line svelte/no-at-html-tags -- close tag contains only the validated tag name -->
+{@html closeTag}


### PR DESCRIPTION
## Summary
- render SSR host attributes for Svelte custom elements, including reflected props
- reuse Svelte's SSR attribute serializer for value escaping and boolean attributes
- add documented helpers for custom element tag validation and prop-to-attribute conversion
- update SSR e2e coverage to assert escaped hostile attribute content is emitted safely

## Validation
- pnpm --filter @svebcomponents/ssr lint
- pnpm --filter @svebcomponents/ssr check
- pnpm --filter @svebcomponents/ssr test
- pnpm --filter @svebcomponents/e2e.ssr test