### PR TITLE
fix: update package repository URL metadata

### DIFF
--- a/packages/auto-options/package.json
+++ b/packages/auto-options/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.4",
   "repository": {
     "type": "git",
-    "url": "https://github.com/svebcomponents/svebcomponents",
+    "url": "git+https://github.com/svebcomponents/svebcomponents.git",
     "directory": "packages/auto-options"
   },
   "scripts": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.8",
   "repository": {
     "type": "git",
-    "url": "https://github.com/svebcomponents/svebcomponents",
+    "url": "git+https://github.com/svebcomponents/svebcomponents.git",
     "directory": "packages/build"
   },
   "type": "module",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.7",
   "repository": {
     "type": "git",
-    "url": "https://github.com/svebcomponents/svebcomponents",
+    "url": "git+https://github.com/svebcomponents/svebcomponents.git",
     "directory": "packages/ssr"
   },
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/svebcomponents/svebcomponents",
+    "url": "git+https://github.com/svebcomponents/svebcomponents.git",
     "directory": "packages/utils"
   },
   "type": "module",


### PR DESCRIPTION
## Summary

Updates published package metadata so `repository.url` uses npm's conventional full git URL format.

## Why

`publint` suggested changing the URL from `https://github.com/svebcomponents/svebcomponents` to `git+https://github.com/svebcomponents/svebcomponents.git`. This applies the same metadata cleanup to:

- `@svebcomponents/auto-options`
- `@svebcomponents/build`
- `@svebcomponents/ssr`
- `@svebcomponents/utils`

This removes the package metadata warning without changing runtime behavior.

## Validation

- `pnpm --filter @svebcomponents/ssr build`
