### PR TITLE
fix(ssr): make ElementRendererRegistry.has() walk the prototype chain

### DIFF
--- a/.changeset/fix-registry-has-prototype-chain.md
+++ b/.changeset/fix-registry-has-prototype-chain.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Fix `ElementRendererRegistry.has()` to correctly walk the element prototype chain, matching the behavior of `get()`.

--- a/packages/ssr/src/lib/runtime/rendererRegistry.test.ts
+++ b/packages/ssr/src/lib/runtime/rendererRegistry.test.ts
@@ -118,4 +118,22 @@ describe("ElementRendererRegistry", () => {
 
     expect(retrieved).toBe(mockRenderer);
   });
+
+  test("has() searches prototype chain for renderer registered on base class", () => {
+    class BaseElement {}
+    class ExtendedElement extends BaseElement {}
+
+    const mockRenderer = class {} as ElementRendererCtor;
+
+    ElementRendererRegistry.set(BaseElement, mockRenderer);
+
+    expect(ElementRendererRegistry.has(ExtendedElement)).toBe(true);
+  });
+
+  test("has() returns false for unregistered classes", () => {
+    class UnregisteredBase {}
+    class UnregisteredExtended extends UnregisteredBase {}
+
+    expect(ElementRendererRegistry.has(UnregisteredExtended)).toBe(false);
+  });
 });

--- a/packages/ssr/src/lib/runtime/rendererRegistry.ts
+++ b/packages/ssr/src/lib/runtime/rendererRegistry.ts
@@ -3,7 +3,7 @@ import type { ElementRendererCtor } from "./types.js";
 declare const globalThis: {
   [REGISTRY_KEY]: _ElementRendererRegistry;
 };
-declare const HTMLElement: unknown;
+declare const HTMLElement: { prototype: unknown };
 
 const REGISTRY_KEY: unique symbol = Symbol.for("ElementRendererRegistry");
 
@@ -36,21 +36,13 @@ class _ElementRendererRegistry {
       }
     } while (
       (targetPrototype = Object.getPrototypeOf(targetPrototype)) &&
-      targetPrototype !== HTMLElement
+      targetPrototype !== HTMLElement.prototype
     );
     return null;
   }
 
   has(elementClass: Element): boolean {
-    const targetPrototype = elementClass.prototype;
-    if (this.renderers.has(targetPrototype)) {
-      return true;
-    }
-    if (targetPrototype === HTMLElement || targetPrototype === undefined) {
-      // not in the registry if null prototype or HTMLElement
-      return false;
-    }
-    return this.has(Object.getPrototypeOf(targetPrototype));
+    return this.get(elementClass) !== null;
   }
 
   getAll() {


### PR DESCRIPTION
## Problem

`ElementRendererRegistry.has()` in `packages/ssr/src/lib/runtime/rendererRegistry.ts` did not correctly walk the element prototype chain, unlike `get()`.

- `has()` recursed by calling `this.has(Object.getPrototypeOf(targetPrototype))`, passing a **prototype** into `has()`, which then immediately dereferenced `.prototype` on it again (`elementClass.prototype`). Since a prototype object doesn't itself have a `.prototype` property, this evaluated to `undefined` and the walk terminated after a single step.
- Verified before the fix: registering a renderer for `Base` and calling `get(Sub)` correctly returned the renderer, but `has(Sub)` incorrectly returned `false`.
- Separately, both `has()` and the termination guard inside `get()`'s loop compared a prototype against the `HTMLElement` **constructor** (`targetPrototype !== HTMLElement`) instead of `HTMLElement.prototype`. That comparison can never be true, so in `get()` the loop only terminated because `Object.getPrototypeOf` eventually returns `null` for the top of the chain — the guard was dead code.
- The package README explicitly advertises subclass lookups: "Lookups walk the element prototype chain, so a renderer registered for a base element class can also serve subclasses." `has()` violated this contract.

## Fix

1. Reimplemented `has()` in terms of `get()`: `has(elementClass) { return this.get(elementClass) !== null; }`. This removes the duplicated (and broken) chain-walking logic entirely and guarantees `has()`/`get()` stay consistent.
2. Fixed `get()`'s termination guard to compare against `HTMLElement.prototype` instead of the `HTMLElement` constructor. `HTMLElement` was declared as `unknown` in this file (it's an ambient global in this runtime-agnostic package); widened the declaration to `{ prototype: unknown }` so `.prototype` can be accessed safely, keeping the existing null-prototype check as a backstop.
3. Added tests in `packages/ssr/src/lib/runtime/rendererRegistry.test.ts`:
   - `has()` returns `true` for a subclass when the renderer is registered for the base class (mirrors the existing `get()` "searches prototype chain" test).
   - `has()` returns `false` for classes with no registered renderer anywhere in their chain.
4. Added a changeset (`@svebcomponents/ssr` patch).

This makes the README's prototype-chain claim (audit item D5) accurate.

## Verification

- `pnpm -F @svebcomponents/ssr build && pnpm -F @svebcomponents/ssr test` — 8 test files, 54 tests passed (includes the 2 new `has()` tests).
- `pnpm build` from repo root — all 10 build tasks succeeded.
- `pnpm test` from repo root — all 17 tasks succeeded (unit + e2e/Playwright chromium suites all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)