### PR TITLE
fix(ssr): remove debug markers from SSR wrapper components

### DIFF
--- a/.changeset/remove-debug-markers.md
+++ b/.changeset/remove-debug-markers.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Remove leftover debug markers (`<p>server</p>` / `<p>client</p>`) from the SSR wrapper components that were leaking into consumer apps' SSR output and breaking hydration matching.

--- a/e2e/ssr/test/server/render.test.ts
+++ b/e2e/ssr/test/server/render.test.ts
@@ -26,26 +26,6 @@ test("rendering svelte", () => {
   expect(res).toStrictEqual(expectedRenderResult);
 });
 
-test("does not render internal debug markers", () => {
-  ElementRendererRegistry.set("simple-component", SimpleComponentRenderer);
-  const res = render(SsrComponent, {
-    props: {
-      title: "SSR Test",
-      count: 5,
-      enabled: true,
-    },
-  });
-
-  // Regression guard for leaked debug markup (e.g. `<p>server</p>` /
-  // `<p>client</p>`) from the SSR wrapper components. We match on the
-  // element itself (tag + text) rather than a raw substring so the
-  // assertion isn't tied to whitespace or Svelte's generated hydration
-  // comment markers, which can legitimately change between Svelte
-  // versions/builds.
-  expect(res.body).not.toMatch(/<p[^>]*>\s*(server|client)\s*<\/p>/);
-  expect(res.html).not.toMatch(/<p[^>]*>\s*(server|client)\s*<\/p>/);
-});
-
 test("escapes untrusted values rendered through shadow props", () => {
   ElementRendererRegistry.set("simple-component", SimpleComponentRenderer);
 

--- a/e2e/ssr/test/server/render.test.ts
+++ b/e2e/ssr/test/server/render.test.ts
@@ -10,8 +10,8 @@ import SsrComponent from "./SsrComponent.svelte";
 
 const expectedRenderResult = {
   head: "",
-  body: '<!--[--><!--[!--><p>server</p> <!--1mdqziy--><simple-component title="SSR Test" count="5" enabled><!----> <template shadowrootmode="open"><!--164jyg1--><!--[--><div><h1>SSR Test</h1> <p id="count">Count: number-5</p> <p id="enabled">Enabled: boolean-true</p></div><!--]--><!----></template> <!----> <!--1llhvfc--></simple-component><!----><!--]--><!--]-->',
-  html: '<!--[--><!--[!--><p>server</p> <!--1mdqziy--><simple-component title="SSR Test" count="5" enabled><!----> <template shadowrootmode="open"><!--164jyg1--><!--[--><div><h1>SSR Test</h1> <p id="count">Count: number-5</p> <p id="enabled">Enabled: boolean-true</p></div><!--]--><!----></template> <!----> <!--1llhvfc--></simple-component><!----><!--]--><!--]-->',
+  body: '<!--[--><!--[!--><!--1mdqziy--><simple-component title="SSR Test" count="5" enabled><!----> <template shadowrootmode="open"><!--164jyg1--><!--[--><div><h1>SSR Test</h1> <p id="count">Count: number-5</p> <p id="enabled">Enabled: boolean-true</p></div><!--]--><!----></template> <!----> <!--1llhvfc--></simple-component><!----><!--]--><!--]-->',
+  html: '<!--[--><!--[!--><!--1mdqziy--><simple-component title="SSR Test" count="5" enabled><!----> <template shadowrootmode="open"><!--164jyg1--><!--[--><div><h1>SSR Test</h1> <p id="count">Count: number-5</p> <p id="enabled">Enabled: boolean-true</p></div><!--]--><!----></template> <!----> <!--1llhvfc--></simple-component><!----><!--]--><!--]-->',
 };
 
 test("rendering svelte", () => {
@@ -24,6 +24,26 @@ test("rendering svelte", () => {
     },
   });
   expect(res).toStrictEqual(expectedRenderResult);
+});
+
+test("does not render internal debug markers", () => {
+  ElementRendererRegistry.set("simple-component", SimpleComponentRenderer);
+  const res = render(SsrComponent, {
+    props: {
+      title: "SSR Test",
+      count: 5,
+      enabled: true,
+    },
+  });
+
+  // Regression guard for leaked debug markup (e.g. `<p>server</p>` /
+  // `<p>client</p>`) from the SSR wrapper components. We match on the
+  // element itself (tag + text) rather than a raw substring so the
+  // assertion isn't tied to whitespace or Svelte's generated hydration
+  // comment markers, which can legitimately change between Svelte
+  // versions/builds.
+  expect(res.body).not.toMatch(/<p[^>]*>\s*(server|client)\s*<\/p>/);
+  expect(res.html).not.toMatch(/<p[^>]*>\s*(server|client)\s*<\/p>/);
 });
 
 test("escapes untrusted values rendered through shadow props", () => {

--- a/packages/ssr/src/lib/vite/Client.svelte
+++ b/packages/ssr/src/lib/vite/Client.svelte
@@ -14,7 +14,6 @@
   }: WebComponentWrapperProps = $props();
 </script>
 
-<p>client</p>
 <svelte:element this={tag} {...props}>
   {@render children?.()}
 </svelte:element>

--- a/packages/ssr/src/lib/vite/Server.svelte
+++ b/packages/ssr/src/lib/vite/Server.svelte
@@ -57,8 +57,6 @@
   const closeTag = `</${tag}>`;
 </script>
 
-<p>server</p>
-
 <!-- eslint-disable-next-line svelte/no-at-html-tags -- tag name is validated above and attributes are escaped by the renderer -->
 {@html openTag}
 <template shadowrootmode="open">


### PR DESCRIPTION
## Problem

`packages/ssr/src/lib/vite/Server.svelte` rendered a literal `<p>server</p>` and `packages/ssr/src/lib/vite/Client.svelte` rendered `<p>client</p>`. These were leftover debug markers that shipped in every custom element rendered through `@svebcomponents/ssr`, injecting debug markup into consumer apps' SSR output and browser DOM. Because the markers only appeared on one side (server vs. client), the server/client trees differed structurally, breaking hydration matching. The existing e2e tests only used `toContain(...)`-style assertions on unrelated content, so they never caught this.

## Fix

1. Removed the `<p>server</p>` line from `Server.svelte` and `<p>client</p>` line from `Client.svelte`.
2. Updated `e2e/ssr/test/server/render.test.ts`:
   - Refreshed the existing `toStrictEqual` snapshot to reflect the corrected (marker-free) output.
   - Added a new regression test, `does not render internal debug markers`, asserting the rendered `body`/`html` do not match `<p ...>server|client</p>`. The assertion uses a tag+text regex (`/<p[^>]*>\s*(server|client)\s*<\/p>/`) rather than a raw substring match, so it is robust to whitespace and won't be tripped up by (nor rely on) Svelte's generated hydration comment markers, which can legitimately change between Svelte versions/builds.
3. Added changeset `.changeset/remove-debug-markers.md` (`@svebcomponents/ssr`: patch).

## Verification

Ran from repo root:

```
pnpm build   # 10/10 tasks successful
pnpm test    # 17/17 tasks successful, all packages/e2e suites green
```

`@svebcomponents/e2e.ssr` test output after the fix:

```
✓ |1| test/server/render.test.ts (5 tests) 24ms
✓ |0 (chromium)| test/client/component.test.ts (2 tests) 316ms

Test Files  2 passed (2)
     Tests  7 passed (7)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)