### PR TITLE
fix(build): CLI no longer silently no-ops and error handler now fires

### DIFF
--- a/.changeset/fix-cli-silent-noop.md
+++ b/.changeset/fix-cli-silent-noop.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/build": patch
+---
+
+Fix the CLI silently exiting with no output when no component exports could be inferred, and fix the error handler so build failures are reported and exit with a non-zero code.

--- a/packages/build/src/cli.ts
+++ b/packages/build/src/cli.ts
@@ -21,20 +21,20 @@ async function main() {
     ],
   });
 
-  if (config === null) {
+  const hasConfig = config != null && config.length > 0;
+
+  if (!hasConfig) {
     console.warn(
       "[svebcomponents]: no valid configuration found. Please ensure to either provide valid `exports` in package.json or a dedicated `svebcomponents.config.js` file.",
     );
   }
 
-  const tsdownOptions = config ?? defineConfig({});
+  const tsdownOptions = hasConfig ? config : defineConfig({});
 
   await Promise.all(tsdownOptions.map(build));
 }
 
-try {
-  main();
-} catch (error) {
+main().catch((error) => {
   console.error("[svebcomponents]: encountered error during build.", error);
   process.exit(1);
-}
+});


### PR DESCRIPTION
## Problem

Two audited issues in `packages/build/src/cli.ts`:

**C4 — silent no-op:** When `package.json` has no export pointing at `dist/client`, `inferComponents()` returns `[]`. An empty array is truthy, so `config ?? defineConfig({})` never falls back to the default config, the "no valid configuration found" warning never fires, and `Promise.all([].map(build))` builds nothing. The CLI exits `0` having done and printed nothing, even though the README's "When Configuration Is Missing" section promises it "falls back to `defineConfig({})`".

**B6 — dead error handler:** `main()` is `async` but was called unawaited inside a synchronous `try { main(); } catch {}`. Rejections from `main()` bypass that `catch` entirely (they become an unhandled promise rejection instead), so the `"[svebcomponents]: encountered error during build."` message and `process.exit(1)` were unreachable dead code. Build failures never surfaced to the user and the process could exit `0` despite failing.

## Fix

In `packages/build/src/cli.ts`:

1. Compute `hasConfig = config != null && config.length > 0` and use that to decide both whether to print the warning and whether to use the loaded config vs. fall back to `defineConfig({})` — matching the README's documented behavior for both the "config file missing" and "no exports inferred" cases.
2. Replace the broken `try { main(); } catch {}` with `main().catch((error) => { console.error(...); process.exit(1); })`, so rejections from the async `main()` are actually caught, reported, and cause a non-zero exit.

The README's "When Configuration Is Missing" section already stated the correct/intended behavior (`defineConfig({})` fallback), so no wording changes were needed there.

## Verification

- `pnpm -F @svebcomponents/build build && pnpm -F @svebcomponents/build test` — build and all 12 unit tests pass.
- Manual repro of the no-config case in a scratch dir (`mktemp -d`) with only `{"name":"t","type":"module","version":"0.0.0"}` as `package.json`, running the built CLI directly:
  ```
  [svebcomponents]: no valid configuration found. Please ensure to either provide valid `exports` in package.json or a dedicated `svebcomponents.config.js` file.
  [svebcomponents]: encountered error during build. Error: Cannot find entry: "src/index.ts"
      ...
  EXIT CODE: 1
  ```
  Previously this exited `0` with zero output; now it warns, then fails loudly with a real error and a non-zero exit code (since `src/index.ts` legitimately doesn't exist in the scratch dir).
- Confirmed a normal build is unaffected: `pnpm -F @svebcomponents/e2e.basic build` completes successfully with exit `0` and no spurious warning.
- Full `pnpm build && pnpm test` from repo root — 17/17 tasks pass.
- Added `.changeset/fix-cli-silent-noop.md` (`@svebcomponents/build`: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)