### PR TITLE
ci: run test suite in CI and gate releases on tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,8 @@ jobs:
       - name: build
         run: pnpm build
 
+      - name: install playwright chromium
+        run: pnpm --filter "@svebcomponents/e2e.basic" exec playwright install --with-deps chromium
+
+      - name: test
+        run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
       - name: install deps
         run: pnpm install
 
+      - name: install playwright chromium
+        run: pnpm --filter "@svebcomponents/e2e.basic" exec playwright install --with-deps chromium
+
+      - name: test
+        run: pnpm test
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Problem

CI (`.github/workflows/ci.yml`) ran type-check, lint, and build — but never `pnpm test`. `.github/workflows/release.yml` published to npm after only `pnpm release` (build + `changeset publish`). As a result, the unit and e2e test suites gated nothing: a PR (or a release) with failing tests could merge/publish cleanly.

## Fix

- `ci.yml`: after the `build` step, add a step to install the Playwright Chromium browser (needed by the `e2e/*` packages' Vitest browser-mode projects, `playwright` catalog version `1.45.0`), then run `pnpm test`.
- `release.yml`: add the same playwright-install + `pnpm test` steps after `pnpm install`, before the `changesets/action` step that publishes to npm — so a release never proceeds with failing tests. (`pnpm build` still runs inside `pnpm release`; the turbo `test` task depends on `build`, so the test step builds what it needs.)

Both new steps match the existing step style (`- name:` / `run:`).

## Verification

Ran the exact commands added to the workflows, locally, from the repo root:

```
pnpm --filter "@svebcomponents/e2e.basic" exec playwright install --with-deps chromium
pnpm test
```

Result: all 17 turbo tasks succeeded, including all e2e/unit suites (basic, auto-options, conditional-export-host, ssr — 2+2+1+6 tests passed).

Also validated:
- `prettier --check` on both workflow files: passes.
- YAML syntax of both files parses cleanly (`yaml.safe_load`).
- `actionlint` was not available via `npx` in this sandbox (no network-installable binary); reviewed the diff manually against the existing step conventions instead.

No changeset added — this is repo CI infrastructure, not a published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)