### PR TITLE
fix(ssr): pass tagName through generated SSR renderer entries

### DIFF
--- a/.changeset/fix-renderer-tagname.md
+++ b/.changeset/fix-renderer-tagname.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Pass the resolved tag name through generated SSR renderer entries so the base `ElementRenderer` receives a defined `tagName`.

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -95,6 +95,8 @@ ElementRendererRegistry.set("my-component", MyComponentRenderer);
 
 You can register by tag name or by constructor. Lookups walk the element prototype chain, so a renderer registered for a base element class can also serve subclasses.
 
+The registry is designed for the Svelte-generated renderers produced by this package. Registered renderers are instantiated with the resolved tag name, so stock Lit `ElementRenderer` classes now receive their `tagName`, but the Svelte wrapper still passes a minimal `RenderInfo` when rendering; full compatibility with arbitrary Lit renderers is therefore not guaranteed.
+
 ### `SvelteCustomElementRenderer`
 
 A base renderer for Svelte custom elements.

--- a/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.test.ts
+++ b/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.test.ts
@@ -61,6 +61,22 @@ describe("pluginGenerateSsrEntry", () => {
         "import ClientSvelteComponent from '../client/index.js'",
       ),
     );
+
+    // The generated renderer must forward the tagName to the base renderer
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/ssr.js"),
+      expect.stringContaining("constructor(tagName)"),
+    );
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/ssr.js"),
+      expect.stringContaining("super(ServerSvelteComponent, ctor, tagName)"),
+    );
+
+    // The generated type declaration exposes the optional tagName parameter
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/ssr.d.ts"),
+      expect.stringContaining("constructor(tagName?: string)"),
+    );
   });
 
   test("uses custom import paths when provided", async () => {

--- a/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts
+++ b/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts
@@ -62,8 +62,8 @@ if (!ctor) {
   throw new Error('Could not access custom element constructor');
 }
 class ComponentSpecificSvelteCustomElementRenderer extends SvelteCustomElementRenderer {
-  constructor() {
-    super(ServerSvelteComponent, ctor);
+  constructor(tagName) {
+    super(ServerSvelteComponent, ctor, tagName);
   }
 }
 
@@ -71,9 +71,8 @@ export default ComponentSpecificSvelteCustomElementRenderer;
 `;
 
       const typesContent = `import { SvelteCustomElementRenderer } from '@svebcomponents/ssr';
-import ServerSvelteComponent from '${serverImportPath}';
 declare class ComponentSpecificSvelteCustomElementRenderer extends SvelteCustomElementRenderer {
-  constructor();
+  constructor(tagName?: string);
 }
 export default ComponentSpecificSvelteCustomElementRenderer;
 `;

--- a/packages/ssr/src/lib/runtime/rendererRegistry.test.ts
+++ b/packages/ssr/src/lib/runtime/rendererRegistry.test.ts
@@ -30,7 +30,9 @@ describe("ElementRendererRegistry", () => {
   test("sets and gets renderer for element class", () => {
     class MockElement {}
 
-    const mockRenderer = class {} as ElementRendererCtor;
+    const mockRenderer = class {
+      constructor(_tagName: string) {}
+    } as ElementRendererCtor;
 
     ElementRendererRegistry.set(MockElement, mockRenderer);
     const retrieved = ElementRendererRegistry.get(MockElement);
@@ -40,7 +42,9 @@ describe("ElementRendererRegistry", () => {
 
   test("sets renderer using string tag name", () => {
     const mockElementClass = class {};
-    const mockRenderer = class {} as ElementRendererCtor;
+    const mockRenderer = class {
+      constructor(_tagName: string) {}
+    } as ElementRendererCtor;
     const tagName = "custom-element";
 
     mockCustomElements.get.mockReturnValue(mockElementClass);
@@ -52,7 +56,9 @@ describe("ElementRendererRegistry", () => {
   });
 
   test("throws error when custom element not found by tag name", () => {
-    const mockRenderer = class {} as ElementRendererCtor;
+    const mockRenderer = class {
+      constructor(_tagName: string) {}
+    } as ElementRendererCtor;
     const tagName = "non-existent-element";
 
     mockCustomElements.get.mockReturnValue(undefined);
@@ -68,8 +74,12 @@ describe("ElementRendererRegistry", () => {
     class MockElement1 {}
     class MockElement2 {}
 
-    const mockRenderer1 = class {} as ElementRendererCtor;
-    const mockRenderer2 = class {} as ElementRendererCtor;
+    const mockRenderer1 = class {
+      constructor(_tagName: string) {}
+    } as ElementRendererCtor;
+    const mockRenderer2 = class {
+      constructor(_tagName: string) {}
+    } as ElementRendererCtor;
 
     ElementRendererRegistry.set(MockElement1, mockRenderer1);
     ElementRendererRegistry.set(MockElement2, mockRenderer2);
@@ -92,7 +102,9 @@ describe("ElementRendererRegistry", () => {
   test("checks if renderer exists for element", () => {
     class MockElement {}
 
-    const mockRenderer = class {} as ElementRendererCtor;
+    const mockRenderer = class {
+      constructor(_tagName: string) {}
+    } as ElementRendererCtor;
 
     expect(ElementRendererRegistry.has(MockElement)).toBe(false);
 
@@ -105,7 +117,9 @@ describe("ElementRendererRegistry", () => {
     class BaseElement {}
     class ExtendedElement extends BaseElement {}
 
-    const mockRenderer = class {} as ElementRendererCtor;
+    const mockRenderer = class {
+      constructor(_tagName: string) {}
+    } as ElementRendererCtor;
 
     ElementRendererRegistry.set(BaseElement, mockRenderer);
     const retrieved = ElementRendererRegistry.get(ExtendedElement);
@@ -117,7 +131,9 @@ describe("ElementRendererRegistry", () => {
     class BaseElement {}
     class ExtendedElement extends BaseElement {}
 
-    const mockRenderer = class {} as ElementRendererCtor;
+    const mockRenderer = class {
+      constructor(_tagName: string) {}
+    } as ElementRendererCtor;
 
     ElementRendererRegistry.set(BaseElement, mockRenderer);
 

--- a/packages/ssr/src/lib/runtime/types.ts
+++ b/packages/ssr/src/lib/runtime/types.ts
@@ -1,5 +1,5 @@
 import { ElementRenderer } from "@lit-labs/ssr";
 
 export interface ElementRendererCtor {
-  new (): ElementRenderer;
+  new (tagName: string): ElementRenderer;
 }

--- a/packages/ssr/src/lib/vite/Server.svelte
+++ b/packages/ssr/src/lib/vite/Server.svelte
@@ -29,7 +29,7 @@
   const CustomElementRendererCtor = ElementRendererRegistry.get(ctor);
   if (!CustomElementRendererCtor)
     throw new Error(`Custom element renderer for ${tag} not found`);
-  const customElementRenderer = new CustomElementRendererCtor();
+  const customElementRenderer = new CustomElementRendererCtor(tag);
   // set attributes / props
   for (const [key, value] of Object.entries(props)) {
     if (key === "_tagName" || key === "children") continue;


### PR DESCRIPTION
## Problem

Two coupled audited issues in `@svebcomponents/ssr`:

- **B4** — The generated SSR entry (`pluginGenerateSsrEntry.ts`) emitted `constructor() { super(ServerSvelteComponent, ctor); }`, never forwarding a `tagName` to `SvelteCustomElementRenderer`, whose constructor is `(svelteSsrComponent, ClientCtor, tagName)`. The base Lit `ElementRenderer` therefore always received `tagName === undefined`. `Server.svelte` likewise instantiated the renderer with zero args. It only worked because the wrappers build the open/close tags themselves.
- **S5** — `ElementRendererCtor` in `types.ts` was typed `new () => ElementRenderer`, overpromising Lit compatibility: stock Lit renderers have `new (tagName: string)` constructors. The README also framed the registry as accepting any `ElementRenderer`.

## Fix

- `pluginGenerateSsrEntry.ts`: generate `constructor(tagName) { super(ServerSvelteComponent, ctor, tagName); }`; the generated `.d.ts` now declares `constructor(tagName?: string)` and drops the dead `ServerSvelteComponent` import.
- `types.ts`: `ElementRendererCtor` is now `new (tagName: string) => ElementRenderer`.
- `Server.svelte`: instantiate with `new CustomElementRendererCtor(tag)`.
- Updated `pluginGenerateSsrEntry.test.ts` for the new generated code.
- Narrowed the README claim: the registry is designed for the Svelte-generated renderers; stock Lit renderers now receive `tagName`, but the wrapper passes a minimal `RenderInfo`, so full Lit renderer support is not guaranteed.
- Added changeset (`@svebcomponents/ssr`: patch).

## Verification

- `pnpm -F @svebcomponents/ssr build && pnpm -F @svebcomponents/ssr test` — 50 tests pass.
- Full `pnpm build && pnpm test` from root — all 17 tasks succeed, including the e2e ssr tests (whose `dist/server/ssr.js` is regenerated by this plugin change).
- Spot-check in `e2e/ssr`:
  ```
  node --input-type=module -e "await import('@svebcomponents/ssr'); await import('./dist/client/index.js'); const R=(await import('./dist/server/ssr.js')).default; console.log(new R('simple-component').tagName)"
  # -> simple-component
  ```

## Note on #66 / AsyncServer

`AsyncServer.svelte` exists only on the unmerged branch `codex/async-ssr-renderers` (draft PR #66) and has the same zero-arg instantiation. It is intentionally not touched here; #66 should apply the same one-line change (`new CustomElementRendererCtor(tag)`) after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)