### PR TITLE
fix(ssr): remove debug marker from AsyncServer (stacked on #66)

### DIFF
--- a/packages/ssr/src/lib/vite/AsyncServer.svelte
+++ b/packages/ssr/src/lib/vite/AsyncServer.svelte
@@ -68,8 +68,6 @@
   const rendered = renderCustomElement(tag, props);
 </script>
 
-<p>server</p>
-
 {#if true}
   {@const renderedCustomElement = await rendered}
   <!-- eslint-disable-next-line svelte/no-at-html-tags -- tag name is validated above and attributes are escaped by the renderer -->


### PR DESCRIPTION
Stacks on #66 (`codex/async-ssr-renderers`, draft).

## Problem

`packages/ssr/src/lib/vite/AsyncServer.svelte` — introduced on the `codex/async-ssr-renderers` branch — carries the same leftover debug marker (`<p>server</p>`) that's being removed from `Server.svelte` / `Client.svelte` on `main` in #68. This marker leaks into consumer apps' SSR output and would break hydration matching once this branch merges.

## Fix

Removed the single `<p>server</p>` line from `AsyncServer.svelte`. No other changes.

`.changeset/async-ssr-renderers.md` (already present on this branch) covers `@svebcomponents/ssr` with a patch bump, so no additional changeset was added.

## Verification

```
pnpm -F @svebcomponents/ssr build
```

```
> @svebcomponents/ssr@0.0.7 build
> svelte-package && publint

src/lib -> dist
Running publint v0.3.21 for @svebcomponents/ssr...
Packing files with `pnpm pack`...
Linting...
All good!
```

Per scope, the full test suite was not run on this branch (base branch #66 is still a draft); only the ssr package build was verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)