### PR TITLE
fix(auto-options): never emit attribute: "undefined" for options-only props

### DIFF
--- a/.changeset/fix-attribute-undefined.md
+++ b/.changeset/fix-attribute-undefined.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/auto-options": patch
+---
+
+Fix inferred props declared only via `<svelte:options customElement={{props: {...}}}>` (without an `attribute` field and without a matching `$props()` destructure) emitting `attribute: "undefined"` instead of falling back to the kebab-cased prop name.

--- a/packages/auto-options/src/fixtures/options_only_prop_no_attribute/input.svelte
+++ b/packages/auto-options/src/fixtures/options_only_prop_no_attribute/input.svelte
@@ -1,0 +1,5 @@
+<svelte:options customElement={{props: {fooBar: {reflect: false}}}}/>
+<script lang="ts">
+  let rest = $props();
+</script>
+<h1>hi</h1>

--- a/packages/auto-options/src/fixtures/options_only_prop_no_attribute/output.svelte
+++ b/packages/auto-options/src/fixtures/options_only_prop_no_attribute/output.svelte
@@ -1,0 +1,7 @@
+<svelte:options customElement={{props: {
+fooBar: {attribute: "foo-bar", reflect: false, type: "String"},
+}}}/>
+<script lang="ts">
+  let rest = $props();
+</script>
+<h1>hi</h1>

--- a/packages/auto-options/src/inferProps.ts
+++ b/packages/auto-options/src/inferProps.ts
@@ -33,8 +33,13 @@ const enhanceInferredProps = (
   // first we check if the propName is already in the inferred props
   const previouslyInferredProp = inferredProps[propName];
   // and then update the previously inferred props, trying to not overwrite previous (more valuable) information
+  // if no attribute name could be inferred from anywhere, fall back to the kebab-cased prop name,
+  // matching Svelte's own default attribute naming behavior
   inferredProps[propName] = {
-    attributeName: previouslyInferredProp?.attributeName ?? attributeName,
+    attributeName:
+      previouslyInferredProp?.attributeName ??
+      attributeName ??
+      kebabize(propName),
     type: previouslyInferredProp?.type ?? type,
     isReflected: previouslyInferredProp?.isReflected ?? isReflected,
   };


### PR DESCRIPTION
## Problem

When a prop is declared only in `<svelte:options customElement={{props: {...}}}>` without an explicit `attribute` field and never appears in the `$props()` destructuring or its types (e.g. rest-props components), `attributeName` stayed `undefined` in `inferProps.ts` (`enhanceInferredProps`), and `injectInferredProps.ts` interpolated it into the generated options as the literal string `"undefined"`. Svelte then observes an attribute literally named `undefined`.

## Repro

```svelte
<svelte:options customElement={{props: {foo: {reflect: false}}}}/>
<script lang="ts">
  let rest = $props();
</script>
<h1>hi</h1>
```

Before this fix, the plugin emitted:

```
foo: {attribute: "undefined", reflect: false, type: "String"}
```

## Fix

In `enhanceInferredProps`, fall back to `kebabize(propName)` when no attribute name could be inferred from any source. This is applied where the prop is first recorded, so the metadata stays consistent, and it matches the documented default ("`attribute`: the kebab-cased prop name" in the README defaults section).

Added a fixture `packages/auto-options/src/fixtures/options_only_prop_no_attribute/` reproducing the rest-props case (a `fooBar` prop is used to also exercise the kebab-casing), plus a changeset.

## Verification

- `pnpm -F @svebcomponents/auto-options build && pnpm -F @svebcomponents/auto-options test` — 22/22 tests pass (including the new fixture)
- Full `pnpm build && pnpm test` from root after rebasing onto latest `main` — 10/10 build tasks, 17/17 test tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d