### PR TITLE
fix(ssr): handle self-closing custom elements in vite transform

### DIFF
--- a/.changeset/fix-self-closing-custom-elements.md
+++ b/.changeset/fix-self-closing-custom-elements.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Fix the SSR Vite plugin corrupting self-closing custom elements (`<my-widget />`), which silently dropped the `_tagName` prop and broke SSR.

--- a/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.test.ts
+++ b/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.test.ts
@@ -1,0 +1,116 @@
+import { expect, test, describe } from "vitest";
+import vitePluginSvebcomponentsSsr from "./vitePluginSvebcomponentsSsr";
+import type { Plugin } from "vite";
+
+type TransformFn = (
+  code: string,
+  id: string,
+) => Promise<{ code: string } | null> | ({ code: string } | null);
+
+/**
+ * The plugin's `transform` hook is defined as a plain async function (not an
+ * object hook), so we can invoke it directly. It does not rely on `this`.
+ */
+const getTransform = (plugin: Plugin): TransformFn =>
+  plugin.transform as unknown as TransformFn;
+
+const transform = async (code: string, id = "Test.svelte") => {
+  const plugin = vitePluginSvebcomponentsSsr();
+  const result = await getTransform(plugin)(code, id);
+  return result?.code ?? null;
+};
+
+describe("vitePluginSvebcomponentsSsr", () => {
+  test("returns plugin with correct name", () => {
+    const plugin = vitePluginSvebcomponentsSsr();
+    expect(plugin.name).toBe("vite-plugin-svelte-webcomponent-wrapper");
+  });
+
+  test("ignores non-svelte files", async () => {
+    const plugin = vitePluginSvebcomponentsSsr();
+    const result = await getTransform(plugin)(
+      "<my-widget></my-widget>",
+      "Test.ts",
+    );
+    expect(result).toBeNull();
+  });
+
+  test("transforms a normal custom element and keeps _tagName", async () => {
+    const output = await transform(`<my-widget count={5}>hi</my-widget>`);
+
+    expect(output).not.toBeNull();
+    // opening tag renamed
+    expect(output).toContain("<CustomElementWrapper");
+    // _tagName prop preserved
+    expect(output).toContain(`_tagName="my-widget"`);
+    // closing tag rewritten
+    expect(output).toContain("</CustomElementWrapper>");
+    // original prop preserved
+    expect(output).toContain("count={5}");
+    // wrapper import added
+    expect(output).toContain(
+      "import CustomElementWrapper from '@svebcomponents/ssr/wrapper-component'",
+    );
+    // no dangling original tag names
+    expect(output).not.toContain("<my-widget");
+    expect(output).not.toContain("</my-widget>");
+  });
+
+  test("transforms a self-closing custom element and keeps _tagName", async () => {
+    const output = await transform(`<my-widget count={5} />`);
+
+    expect(output).not.toBeNull();
+    expect(output).toContain("<CustomElementWrapper");
+    // the critical assertion: _tagName must not be lost
+    expect(output).toContain(`_tagName="my-widget"`);
+    expect(output).toContain("count={5}");
+    // self-closing stays self-closing, no bogus closing tag introduced
+    expect(output).toContain("/>");
+    expect(output).not.toContain("</CustomElementWrapper>");
+    // no corruption of surrounding characters (would show up as a stray tag)
+    expect(output).not.toContain("<my-widget");
+  });
+
+  test("self-closing sibling does not corrupt an earlier same-tag element", async () => {
+    const output = await transform(`<my-el></my-el><my-el />`);
+
+    expect(output).not.toBeNull();
+    // first element: full open + close rewrite
+    // second element: self-closing, _tagName kept
+    // both opening tags renamed
+    const openWrappers = output!.match(/<CustomElementWrapper/g) ?? [];
+    expect(openWrappers).toHaveLength(2);
+    // exactly one closing tag (from the first, non-self-closing element)
+    const closeWrappers = output!.match(/<\/CustomElementWrapper>/g) ?? [];
+    expect(closeWrappers).toHaveLength(1);
+    // both elements carry the _tagName prop
+    const tagNameProps = output!.match(/_tagName="my-el"/g) ?? [];
+    expect(tagNameProps).toHaveLength(2);
+    // the first element's closing tag must not have been clobbered into garbage
+    expect(output).not.toContain("</my-el>");
+    expect(output).not.toContain("<my-el");
+  });
+
+  test("nested same-tag elements map their closing tags correctly", async () => {
+    const output = await transform(`<my-box><my-box>inner</my-box></my-box>`);
+
+    expect(output).not.toBeNull();
+    const openWrappers = output!.match(/<CustomElementWrapper/g) ?? [];
+    expect(openWrappers).toHaveLength(2);
+    const closeWrappers = output!.match(/<\/CustomElementWrapper>/g) ?? [];
+    expect(closeWrappers).toHaveLength(2);
+    const tagNameProps = output!.match(/_tagName="my-box"/g) ?? [];
+    expect(tagNameProps).toHaveLength(2);
+    // no original tag names left behind
+    expect(output).not.toContain("<my-box");
+    expect(output).not.toContain("</my-box>");
+    expect(output).toContain("inner");
+  });
+
+  test("leaves non-custom (plain) elements untouched", async () => {
+    const output = await transform(`<div class="a"><span>hi</span></div>`);
+
+    // nothing to transform => plugin returns null (no changes)
+    expect(output).toBeNull();
+  });
+});

--- a/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts
+++ b/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts
@@ -120,21 +120,33 @@ function vitePluginSvebcomponentsSsr(): Plugin {
                   ` ${WRAPPER_TAG_NAME_PROP}="${originalTagName}"`,
                 );
 
-                // Find the ce's closing tag, searching backwards from the node's end (to avoid nested elements)
+                // Find the ce's closing tag, searching backwards from the
+                // node's last character (`node.end` is exclusive, so we use
+                // `node.end - 1` — otherwise a same-tag parent's closing tag,
+                // which starts exactly at a nested child's `node.end`, would be
+                // matched for the child and corrupt the mapping).
                 const closingTagStart = code.lastIndexOf(
                   `</${originalTagName}>`,
-                  node.end,
+                  node.end - 1,
                 );
-                const closingTagNameStart = closingTagStart + 2; // Index after '</'
-                const closingTagNameEnd =
-                  closingTagNameStart + originalTagName.length;
-                // replace ce closing tag with wrapper component closing tag
-                magicString.overwrite(
-                  closingTagNameStart,
-                  closingTagNameEnd,
-                  WRAPPER_COMPONENT_NAME,
-                  { storeName: true },
-                );
+                // If no closing tag exists within this element's range, it is
+                // self-closing (`<my-widget />`). `lastIndexOf` returns -1 in
+                // that case, or an index before this node's start when the only
+                // match belongs to an earlier same-tag sibling. Either way, skip
+                // the closing-tag overwrite: a self-closing
+                // `<CustomElementWrapper _tagName="..." ... />` is valid Svelte.
+                if (closingTagStart >= node.start) {
+                  const closingTagNameStart = closingTagStart + 2; // Index after '</'
+                  const closingTagNameEnd =
+                    closingTagNameStart + originalTagName.length;
+                  // replace ce closing tag with wrapper component closing tag
+                  magicString.overwrite(
+                    closingTagNameStart,
+                    closingTagNameEnd,
+                    WRAPPER_COMPONENT_NAME,
+                    { storeName: true },
+                  );
+                }
 
                 shouldAddImport = true;
               }


### PR DESCRIPTION
## Problem

The SSR Vite plugin (`packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts`) corrupts self-closing custom elements. The closing-tag rewrite uses `code.lastIndexOf("</my-widget>", node.end)`, which returns `-1` when the element is self-closing, making `closingTagNameStart = 1` and overwriting a bogus code range. The bogus overwrite clobbers the `appendLeft` that injects the `_tagName` prop, so the Server wrapper later throws `Invalid custom element tag name: undefined` on every SSR request.

Two related lookup bugs in the same code path:
- With same-tag siblings (`<my-el></my-el><my-el />`), the lookup for the self-closing element matched the earlier sibling's closing tag and corrupted it.
- `node.end` is exclusive, so for nested same-tag elements the child's lookup could match the parent's closing tag (which starts exactly at the child's `node.end`).

## Repro

Before this fix, transforming `<my-widget count={5} />` yielded:

```svelte
<CustomElementWrapper count={5} />
```

The `_tagName` prop is silently lost, breaking SSR at runtime.

## Fix

- Search for the closing tag from `node.end - 1` (excludes a same-tag parent's closing tag at the child's exclusive end).
- Skip the closing-tag overwrite when the lookup returns `-1` or an index `< node.start` (self-closing element, or the only match belongs to an earlier sibling). A self-closing `<CustomElementWrapper _tagName="..." ... />` is valid Svelte; the opening-tag rename and `_tagName` injection still happen.
- Adds the plugin's first unit tests (`vitePluginSvebcomponentsSsr.test.ts`) covering: normal transform, self-closing, same-tag siblings, nested same-tag elements, non-custom elements, and non-svelte files.
- Adds a patch changeset for `@svebcomponents/ssr`.

## Verification

After the fix:

```
"<my-widget count={5} />"
  => <CustomElementWrapper _tagName="my-widget" count={5} />

"<my-el></my-el><my-el />"
  => <CustomElementWrapper _tagName="my-el"></CustomElementWrapper><CustomElementWrapper _tagName="my-el" />
```

- `pnpm -F @svebcomponents/ssr build && pnpm -F @svebcomponents/ssr test`: 10 test files, 68 tests passed
- Full `pnpm build`: 10/10 tasks successful
- Full `pnpm test` (incl. Playwright e2e SSR): 17/17 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d