### PR TITLE
fix(ssr): don't clobber existing DOM shim globals on install

### DIFF
--- a/.changeset/fix-installshim-clobber.md
+++ b/.changeset/fix-installshim-clobber.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Fix `installShim` unconditionally overwriting existing `Element`, `HTMLElement`, and `customElements` globals, which silently dropped custom elements already registered by another DOM shim or jsdom-based test setup.

--- a/packages/ssr/src/lib/runtime/installShim.test.ts
+++ b/packages/ssr/src/lib/runtime/installShim.test.ts
@@ -1,0 +1,66 @@
+import { expect, test, describe, afterEach, vi } from "vitest";
+
+// The shim module installs its globals as a side effect at import time, so
+// each test needs a fresh module registry (vi.resetModules) and a fresh
+// dynamic import to observe the install logic running under different
+// pre-existing global states.
+
+describe("installShim", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  test("does not replace a pre-existing customElements registry", async () => {
+    const existingCustomElements = {
+      get: vi.fn(),
+      define: vi.fn(),
+      whenDefined: vi.fn(),
+    };
+    const existingElement = class ExistingElement {};
+    const existingHTMLElement = class ExistingHTMLElement {};
+
+    vi.stubGlobal("customElements", existingCustomElements);
+    vi.stubGlobal("Element", existingElement);
+    vi.stubGlobal("HTMLElement", existingHTMLElement);
+
+    vi.resetModules();
+    await import("./installShim");
+
+    expect(globalThis.customElements).toBe(existingCustomElements);
+    expect(globalThis.Element).toBe(existingElement);
+    expect(globalThis.HTMLElement).toBe(existingHTMLElement);
+  });
+
+  test("installs Element, HTMLElement, and customElements when not already defined", async () => {
+    vi.stubGlobal("customElements", undefined);
+    vi.stubGlobal("Element", undefined);
+    vi.stubGlobal("HTMLElement", undefined);
+
+    vi.resetModules();
+    await import("./installShim");
+
+    expect(globalThis.customElements).toBeDefined();
+    expect(globalThis.Element).toBeDefined();
+    expect(globalThis.HTMLElement).toBeDefined();
+  });
+
+  test("installs globals independently when only some are already present", async () => {
+    const existingCustomElements = {
+      get: vi.fn(),
+      define: vi.fn(),
+      whenDefined: vi.fn(),
+    };
+
+    vi.stubGlobal("customElements", existingCustomElements);
+    vi.stubGlobal("Element", undefined);
+    vi.stubGlobal("HTMLElement", undefined);
+
+    vi.resetModules();
+    await import("./installShim");
+
+    expect(globalThis.customElements).toBe(existingCustomElements);
+    expect(globalThis.Element).toBeDefined();
+    expect(globalThis.HTMLElement).toBeDefined();
+  });
+});

--- a/packages/ssr/src/lib/runtime/installShim.ts
+++ b/packages/ssr/src/lib/runtime/installShim.ts
@@ -10,6 +10,10 @@ declare const globalThis: {
   customElements: InstanceType<typeof CustomElementRegistry>;
 };
 
-globalThis.Element = Element;
-globalThis.HTMLElement = HTMLElement;
-globalThis.customElements = new CustomElementRegistry();
+// Only install each global when it isn't already defined. An environment may
+// already have some (but not all) of these set up by another copy/version of
+// this package, @lit-labs/ssr itself, or a jsdom-based test setup — clobbering
+// them would silently drop any custom elements already registered there.
+globalThis.Element ??= Element;
+globalThis.HTMLElement ??= HTMLElement;
+globalThis.customElements ??= new CustomElementRegistry();


### PR DESCRIPTION
## Problem

`packages/ssr/src/lib/runtime/installShim.ts` unconditionally overwrote `globalThis.Element`, `globalThis.HTMLElement`, and `globalThis.customElements` on import. If anything had already installed a registry (another copy/version of this package, `@lit-labs/ssr` itself, or a jsdom-based test setup), all previously registered custom elements were silently lost — element definition and renderer registration would then disagree confusingly.

## Fix

- Guard each assignment with `??=` so each global is only installed when not already defined, and each is installed independently (an environment may have some but not others). This matches how `@lit-labs/ssr-dom-shim` guards its own global installs (`globalThis.Event ??= EventShim;` etc.).
- Added `installShim.test.ts` covering three cases: a pre-existing `customElements`/`Element`/`HTMLElement` set is not replaced; a bare environment gets all three installed; a partially populated environment gets only the missing globals installed. The module installs at import time, so each test uses `vi.resetModules()` + dynamic import.
- Added changeset `fix-installshim-clobber.md` (`@svebcomponents/ssr`: patch).

## Verification

- `pnpm -F @svebcomponents/ssr build` — passes (svelte-package + publint clean)
- `pnpm -F @svebcomponents/ssr test` — 10 test files, 60 tests passed (includes the 3 new installShim tests and the rendererRegistry tests from #67)
- Full `pnpm build` from root — 10/10 tasks successful
- Full `pnpm test` from root — 17/17 tasks successful, including the e2e ssr suite (`test/server/render.test.ts` 4 tests + client 2 tests), confirming the shim still installs in a bare SSR environment
- Branch rebased onto latest `origin/main` (includes #67–#70) before opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d