### PR TITLE
fix(auto-options): don't crash on customElement string option

### DIFF
--- a/.changeset/fix-string-customelement-crash.md
+++ b/.changeset/fix-string-customelement-crash.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/auto-options": patch
+---
+
+Fix crash when using `<svelte:options customElement="tagName"/>` (the string variant); it now emits the unsupported-variant warning without throwing, and leaves svelte:options untouched.

--- a/packages/auto-options/src/customElementStringVariant.test.ts
+++ b/packages/auto-options/src/customElementStringVariant.test.ts
@@ -1,0 +1,38 @@
+import { expect, test, vi } from "vitest";
+import autoOptions from "./autoOptions";
+
+const svelteId = "t.svelte";
+
+// Regression test for B3: `<svelte:options customElement="tag-name"/>` (the quoted string
+// variant) used to crash the plugin with `TypeError: Cannot read properties of undefined
+// (reading 'type')`, because the code assumed `customElement`'s attribute value was always an
+// `ExpressionTag` with an `expression` property. It's actually an array of `Text` nodes for the
+// string variant.
+//
+// Since the string variant is not supported, and a `customElement` attribute is already present,
+// the plugin must not inject a second `customElement={{...}}` attribute either (that would be a
+// Svelte compile error) - it should leave the component untouched (return `null`).
+test("auto-options does not crash and returns null for customElement string variant", async () => {
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  const input = `<svelte:options customElement="my-tag"/>
+<script lang="ts">
+  interface Props {
+    numberProp: number;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>
+`;
+
+  const result = await autoOptions().transform(input, svelteId);
+
+  expect(result).toBe(null);
+  expect(warnSpy).toHaveBeenCalledWith(
+    expect.stringContaining(
+      'Svelte Options with the format `<svelte:options customElement="tagName"/>` are currently not supported.',
+    ),
+  );
+
+  warnSpy.mockRestore();
+});

--- a/packages/auto-options/src/extractSvelteOptionsProps.ts
+++ b/packages/auto-options/src/extractSvelteOptionsProps.ts
@@ -12,6 +12,11 @@ export interface SvelteOptions {
       propValues: Record<string, Record<string, unknown>>;
     } | null;
   } | null;
+  // true when `<svelte:options customElement="tagName"/>` (the string variant) was found.
+  // This variant is currently not supported, and since a `customElement` attribute is already
+  // present, we must not inject a second one (which would be a Svelte compile error), so callers
+  // need to bail out of any further svelte:options mutation in this case.
+  hasUnsupportedStringCustomElement?: boolean;
 }
 
 export const extractSvelteOptions = (
@@ -23,8 +28,7 @@ export const extractSvelteOptions = (
   const attributeInjectIndex = svelteOptions.end - 2;
 
   const customElementSvelteOptions = svelteOptions?.attributes.find(
-    (attr): attr is AST.Attribute & { value: AST.ExpressionTag } =>
-      attr.name === "customElement",
+    (attr) => attr.name === "customElement",
   );
   if (!customElementSvelteOptions) {
     return {
@@ -33,10 +37,17 @@ export const extractSvelteOptions = (
     };
   }
 
-  const {
-    value: { expression },
-  } = customElementSvelteOptions;
+  // the value of a `customElement` attribute isn't always an `ExpressionTag`:
+  // - `customElement` (boolean shorthand) has a value of `true`
+  // - `customElement="tagName"` (the quoted string variant) has a value that is an array of `Text`/`ExpressionTag` nodes
+  // only the object variant `customElement={{...}}` has an `ExpressionTag` value with an `expression` we can inspect
+  const customElementValue = customElementSvelteOptions.value;
+  const expression =
+    customElementValue !== true && !Array.isArray(customElementValue)
+      ? customElementValue.expression
+      : undefined;
   if (
+    !expression ||
     expression.type !== "ObjectExpression" ||
     !("end" in expression && typeof expression["end"] === "number")
   ) {
@@ -46,6 +57,7 @@ export const extractSvelteOptions = (
     return {
       attributeInjectIndex,
       customElementOptions: null,
+      hasUnsupportedStringCustomElement: true,
     };
   }
   // if custom element options exist, but no props

--- a/packages/auto-options/src/injectInferredProps.ts
+++ b/packages/auto-options/src/injectInferredProps.ts
@@ -13,6 +13,13 @@ export const injectInferredProps = (
     ([, inferredProp]) => !inferredProp.isNonSerializable,
   );
   if (serializableProps.length === 0) return;
+
+  // if the user already declared `<svelte:options customElement="tagName"/>` (the currently
+  // unsupported string variant), a `customElement` attribute is already present on svelte:options.
+  // We must not inject a second `customElement={{...}}` attribute, since that would be a Svelte
+  // compile error, so we leave svelte:options untouched entirely.
+  if (svelteOptions?.hasUnsupportedStringCustomElement) return;
+
   let inferredPropsResult = "props: {\n";
   for (const [propName, inferredProp] of serializableProps) {
     inferredPropsResult += `${propName}: {attribute: "${inferredProp.attributeName}", reflect: ${inferredProp.isReflected}, type: "${inferredProp.type}"},\n`;


### PR DESCRIPTION
## Problem

The auto-options plugin crashed on any component using the string variant of the custom element option:

```svelte
<svelte:options customElement="my-tag"/>
```

In `extractSvelteOptionsProps.ts`, `const { value: { expression } } = customElementSvelteOptions` assumed the attribute value is always an `ExpressionTag`. For the quoted string form, the value is an array of `Text` nodes, so `expression` is `undefined` and `expression.type` threw `TypeError: Cannot read properties of undefined (reading 'type')` — before ever reaching the code's own friendly "string variant not supported" message. This killed the whole build with an opaque error.

## Repro

Run any component with `<svelte:options customElement="my-tag"/>` through `autoOptions().transform(...)` — the build dies with the TypeError above.

## Fix

- Guard the attribute value shape before accessing `.expression`: only treat it as the object variant when the value is an `ExpressionTag`. Boolean shorthand (`value === true`) and the string variant (array of Text nodes) fall through to the unsupported path.
- Emit the intended warning via `console.warn` instead of crashing.
- Signal the unsupported string variant on the returned `SvelteOptions` (`hasUnsupportedStringCustomElement`) and bail out of injection in `injectInferredProps.ts` — previously the flow would have appended a second `customElement={{...}}` attribute onto the existing `svelte:options`, which is a Svelte compile error (duplicate attribute). The plugin now leaves the component untouched (transform returns `null`).
- Added a dedicated unit test (`customElementStringVariant.test.ts`) asserting the transform returns `null`, does not throw, and emits the warning. (The fixture harness asserts non-null transform results, so a no-change case needs a dedicated test.)
- Added changeset `fix-string-customelement-crash.md` (`@svebcomponents/auto-options`: patch).

## Verification

- `pnpm -F @svebcomponents/auto-options build` — passes
- `pnpm -F @svebcomponents/auto-options test` — 22 tests passed (21 existing fixtures + new regression test)
- Manual repro through the built plugin (`node --input-type=module` against `dist/index.js`): prints the warning and returns `null`, no crash
- Full `pnpm build` (10/10 tasks) and `pnpm test` (17/17 tasks) from root — all green
- Branch rebased onto latest `origin/main` (post #67–#70) before opening this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d