### PR TITLE
fix(utils): allow digits in isKebabCase attribute names

### DIFF
--- a/.changeset/fix-iskebabcase-digits.md
+++ b/.changeset/fix-iskebabcase-digits.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/utils": patch
+---
+
+Allow digits in `isKebabCase` so attribute names like `col-2` or `heading2` are correctly detected as attributes, fixing SSR/client markup divergence.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,9 @@
     "lint:format": "prettier --check .",
     "fix": "pnpm /^fix:.*/",
     "fix:eslint": "eslint . --fix",
-    "fix:format": "prettier --write ."
+    "fix:format": "prettier --write .",
+    "test": "vitest run",
+    "test:dev": "vitest --watch"
   },
   "exports": {
     ".": {
@@ -29,7 +31,8 @@
     "@svebcomponents/prettier-config": "workspace:*",
     "@svebcomponents/typescript-config": "workspace:*",
     "svelte": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "dependencies": {},
   "publishConfig": {

--- a/packages/utils/src/index.test.ts
+++ b/packages/utils/src/index.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import { camelizeKebabCase, isKebabCase, kebabize } from "./index";
+
+describe("kebabize", () => {
+  test("converts camelCase to kebab-case", () => {
+    expect(kebabize("camelCase")).toBe("camel-case");
+  });
+
+  test("converts multi-word camelCase to kebab-case", () => {
+    expect(kebabize("ariaColIndex")).toBe("aria-col-index");
+  });
+
+  test("leaves single lowercase words unchanged", () => {
+    expect(kebabize("word")).toBe("word");
+  });
+
+  test("handles consecutive uppercase letters as a single group", () => {
+    expect(kebabize("URLValue")).toBe("url-value");
+  });
+
+  test("returns an empty string for an empty input", () => {
+    expect(kebabize("")).toBe("");
+  });
+});
+
+describe("isKebabCase", () => {
+  test("accepts kebab-case strings", () => {
+    expect(isKebabCase("kebab-case")).toBe(true);
+  });
+
+  test("accepts a single lowercase word", () => {
+    expect(isKebabCase("word")).toBe(true);
+  });
+
+  test("accepts digits after the leading letter", () => {
+    expect(isKebabCase("heading2")).toBe(true);
+  });
+
+  test("accepts digits within a kebab segment", () => {
+    expect(isKebabCase("col-2")).toBe(true);
+  });
+
+  test("accepts digits mixed into a compound attribute name", () => {
+    expect(isKebabCase("aria-colindex2")).toBe(true);
+  });
+
+  test("rejects strings starting with a digit", () => {
+    expect(isKebabCase("2fast")).toBe(false);
+  });
+
+  test("rejects leading dashes (e.g. CSS custom properties)", () => {
+    expect(isKebabCase("--css-variable")).toBe(false);
+  });
+
+  test("rejects camelCase strings", () => {
+    expect(isKebabCase("camelCase")).toBe(false);
+  });
+
+  test("rejects an empty string", () => {
+    expect(isKebabCase("")).toBe(false);
+  });
+});
+
+describe("camelizeKebabCase", () => {
+  test("converts kebab-case to camelCase", () => {
+    expect(camelizeKebabCase("kebab-case")).toBe("kebabCase");
+  });
+
+  test("leaves single lowercase words unchanged", () => {
+    expect(camelizeKebabCase("word")).toBe("word");
+  });
+
+  test("round-trips with kebabize for multi-word attributes", () => {
+    const original = "ariaColIndex";
+    expect(camelizeKebabCase(kebabize(original))).toBe(original);
+  });
+
+  test("handles digit segments", () => {
+    expect(camelizeKebabCase("col-2")).toBe("col2");
+  });
+
+  test("round-trips digit segments with kebabize", () => {
+    const original = "heading2";
+    expect(camelizeKebabCase(kebabize(original))).toBe(original);
+  });
+
+  test("returns an empty string for an empty input", () => {
+    expect(camelizeKebabCase("")).toBe("");
+  });
+});

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,10 +12,13 @@ export const kebabize = (str: string) =>
  * Example:
  * kebab-case → true
  * word -> true
+ * col-2 → true
+ * heading2 → true
  * --css-variable → false
  * camelCase → false
  */
-export const isKebabCase = (str: string) => /^([a-z])+(-[a-z]+)*$/.test(str);
+export const isKebabCase = (str: string) =>
+  /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(str);
 
 /**
  * A utility to convert kebab-case to camelCase

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.8.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.13.2)(@vitest/browser@3.2.4)(jiti@2.5.1)(yaml@2.9.0)
 
 packages:
 
@@ -8604,15 +8607,15 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.0.6(@types/node@22.14.1)(jiti@2.5.1)(yaml@2.9.0)
@@ -8647,15 +8650,15 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.0.6(@types/node@24.13.2)(jiti@2.5.1)(yaml@2.9.0)


### PR DESCRIPTION
## Problem

`isKebabCase` in `packages/utils/src/index.ts` used the regex `/^([a-z])+(-[a-z]+)*$/`, which rejects any name containing a digit (`heading2`, `col-2`, `aria-colindex2`, ...). In the SSR server wrapper (`packages/ssr/src/lib/vite/Server.svelte`), a string prop whose key fails `isKebabCase` is set as a *property* instead of an *attribute*, while the client (`<svelte:element {...props}>`) renders it as an attribute — so server and client markup diverged for any attribute name containing a digit. (Audit issue B8.)

## Fix

- Updated the regex to `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/`, allowing digits after the leading letter while keeping the documented rejections (`--css-variable`, `camelCase`, leading digit) intact. JSDoc examples updated to mention digit support.
- Added the first test suite for `@svebcomponents/utils` (`packages/utils/src/index.test.ts`, 20 tests) covering `kebabize`, `isKebabCase` (digit cases, single words, leading-dash rejection, camelCase rejection, empty string), and `camelizeKebabCase` (including digit segments and round-tripping with `kebabize`).
- Wired up vitest for the package (`test`/`test:dev` scripts + `vitest: catalog:` devDependency, mirroring `packages/auto-options`); turbo picks up the `test` script automatically.
- Added changeset `fix-iskebabcase-digits` (`@svebcomponents/utils`: patch).

## Verification

- `pnpm -F @svebcomponents/utils test` — 20/20 tests pass
- `pnpm -F @svebcomponents/utils build` — clean tsc build
- Full `pnpm build` from root — 10/10 tasks successful
- Full `pnpm test` from root — 18/18 tasks successful (incl. e2e ssr/client suites)

Branch rebased onto latest `origin/main` (after #67–#70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d