### PR TITLE
fix: declare consistent Node engines across published packages and CI

### DIFF
--- a/.changeset/fix-node-engines.md
+++ b/.changeset/fix-node-engines.md
@@ -1,0 +1,8 @@
+---
+"@svebcomponents/build": patch
+"@svebcomponents/ssr": patch
+"@svebcomponents/auto-options": patch
+"@svebcomponents/utils": patch
+---
+
+Declare supported Node versions (`engines.node: ">=20.19.0"`) so consumers get a clear error instead of an opaque runtime failure on unsupported Node versions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: install node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: "pnpm"
 
       - name: install deps

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad",
   "engines": {
-    "node": ">=18"
+    "node": ">=20.19.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/auto-options/package.json
+++ b/packages/auto-options/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@svebcomponents/auto-options",
   "version": "0.0.4",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/svebcomponents/svebcomponents.git",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@svebcomponents/build",
   "version": "0.0.8",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/svebcomponents/svebcomponents.git",

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@svebcomponents/ssr",
   "version": "0.0.7",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/svebcomponents/svebcomponents.git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@svebcomponents/utils",
   "version": "0.0.2",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/svebcomponents/svebcomponents.git",


### PR DESCRIPTION
## Problem

Node version support was inconsistent, and the CLI broke on the advertised floor:

- Root `package.json` declared `engines.node: ">=18"`, but `packages/build/bin.js` uses `import.meta.dirname`, which requires Node >= 20.11 — a Node 18 user running the CLI got an opaque `TypeError` instead of a clear engine error.
- None of the four published packages (`@svebcomponents/{build,ssr,auto-options,utils}`) declared `engines` at all, so the repo's `.npmrc` `engine-strict = true` enforced nothing for consumers.
- CI pinned Node 22 inline while the release workflow and `.nvmrc` use Node 24 — two sources of truth.

## Chosen floor: `>=20.19.0`

Max of the runtime-dependency requirements and the syntax floor (verified against the installed packages in `node_modules`):

| Requirement | engines.node | Used by |
| --- | --- | --- |
| `tsdown@0.15.12` | `>=20.19.0` | runtime dep of `@svebcomponents/build` (strictest) |
| `import.meta.dirname` in `packages/build/bin.js` | >= 20.11 (Node feature) | `@svebcomponents/build` CLI |
| `vite@7.0.6` (catalog) | `^20.19.0 \|\| >=22.12.0` | dev/e2e tooling |
| `rolldown@1.0.0-beta.29` | none declared | runtime dep of `@svebcomponents/ssr` |
| `@lit-labs/ssr@3.3.1` | `>=13.9.0` | runtime dep of `@svebcomponents/ssr` |
| `svelte@5` | `>=18` | peer/runtime |

## Fix

- Set `engines.node: ">=20.19.0"` in the root `package.json` and in all four published packages, so `engine-strict` (and consumers' package managers) now actually enforce a working floor.
- Changed `.github/workflows/ci.yml` to use `node-version-file: .nvmrc` (matching `release.yml`), making `.nvmrc` the single source of truth for the CI Node version.
- Added changeset `.changeset/fix-node-engines.md` with patch bumps for all four published packages.

No lockfile changes resulted (`pnpm install` after the edits produced no diff).

## Verification

- `pnpm install` — succeeds on Node 24.5.0 with `engine-strict = true` (no engine rejection).
- `pnpm build` — 10/10 tasks successful.
- `pnpm test` — 17/17 tasks successful, all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d