### PR TITLE
fix(build,ssr): generate SSR entry filenames from declared exports

### DIFF
--- a/.changeset/fix-multi-component-ssr-entries.md
+++ b/.changeset/fix-multi-component-ssr-entries.md
@@ -1,0 +1,10 @@
+---
+"@svebcomponents/build": patch
+"@svebcomponents/ssr": patch
+---
+
+Generate the SSR renderer entry filename from the declared package export instead of hardcoding `ssr.js`.
+
+Previously every SSR build wrote `<ssrOutDir>/ssr.js` regardless of the declared export. This meant the multi-component setup documented in the build README (e.g. `"./button/ssr": "./dist/server/button-ssr.js"`) produced a dangling export, and two SSR components sharing an output directory overwrote each other's generated entry.
+
+`inferComponents` now derives the entry basename from the declared ssr export path, and a new `ssrEntryFileName` option on `defineConfig` (defaulting to `"ssr"`) threads it through `svebcomponentsSsr` into `pluginGenerateSsrEntry`. Single-component behavior is unchanged.

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -29,6 +29,13 @@ export interface DefineConfigOptions {
    * The output directory for the Svelte-aware SSR build files.
    */
   ssrSvelteOutDir?: string;
+  /**
+   * The basename (without extension) of the generated SSR renderer entry file.
+   * Defaults to "ssr", producing `<ssrOutDir>/ssr.js`. When several SSR
+   * components share an SSR output directory this must be unique per component
+   * (e.g. "button-ssr") so the generated entries do not overwrite each other.
+   */
+  ssrEntryFileName?: string;
 }
 
 const toImportPath = (fromDirectory: string, toFile: string) => {
@@ -51,6 +58,7 @@ export const defineConfig = (options: DefineConfigOptions = {}) => {
   const svelteOutDir = options.svelteOutDir;
   const ssrOutDir = options.ssrOutDir ?? "dist/server";
   const ssrSvelteOutDir = options.ssrSvelteOutDir;
+  const ssrEntryFileName = options.ssrEntryFileName ?? "ssr";
 
   const tsdownOptions: Options[] = [
     createTsdownConfig({
@@ -74,6 +82,7 @@ export const defineConfig = (options: DefineConfigOptions = {}) => {
       svebcomponentsSsr({
         entry,
         outDir: ssrOutDir,
+        ssrEntryFileName,
         serverImportPath: `./${path.posix.basename(entryOutputFile(ssrOutDir, entry))}`,
         clientImportPath: toImportPath(
           ssrOutDir,
@@ -88,6 +97,7 @@ export const defineConfig = (options: DefineConfigOptions = {}) => {
           entry,
           outDir: ssrSvelteOutDir,
           externalSvelte: true,
+          ssrEntryFileName,
           serverImportPath: `./${path.posix.basename(
             entryOutputFile(ssrSvelteOutDir, entry),
           )}`,

--- a/packages/build/src/inferComponents.test.ts
+++ b/packages/build/src/inferComponents.test.ts
@@ -2,10 +2,57 @@ import { describe, expect, it, type MockedFunction, vi } from "vitest";
 import { inferComponents } from "./inferComponents";
 import { defineConfig } from "./index.js";
 import fs from "node:fs";
+import path from "node:path";
+import fsPromises from "fs/promises";
+import type { Options } from "tsdown";
 
 vi.mock("node:fs");
 const mockFs = fs as unknown as {
   existsSync: MockedFunction<typeof fs.existsSync>;
+};
+
+vi.mock("fs/promises", () => ({
+  default: { writeFile: vi.fn() },
+}));
+const mockWriteFile = fsPromises.writeFile as unknown as MockedFunction<
+  typeof fsPromises.writeFile
+>;
+
+/**
+ * Drive every generated SSR-entry plugin found in the given tsdown configs and
+ * collect the file paths it writes. This exercises the actual `writeBundle`
+ * side effect (which `JSON.stringify` comparisons cannot observe, since the
+ * entry filename is captured inside the plugin closure).
+ */
+const collectGeneratedSsrFiles = async (
+  configs: Options[],
+): Promise<string[]> => {
+  mockWriteFile.mockClear();
+  for (const config of configs) {
+    const plugins = (config.plugins ?? []) as Array<{
+      name?: string;
+      writeBundle?: (
+        this: { error: (msg: string) => never },
+        outputOptions: { dir?: string | undefined },
+      ) => unknown;
+    }>;
+    for (const plugin of plugins) {
+      if (
+        plugin?.name === "svebcomponents:generate-ssr-entry" &&
+        typeof plugin.writeBundle === "function"
+      ) {
+        await plugin.writeBundle.call(
+          {
+            error: (msg: string) => {
+              throw new Error(msg);
+            },
+          },
+          { dir: config.outDir },
+        );
+      }
+    }
+  }
+  return mockWriteFile.mock.calls.map((call) => String(call[0]));
 };
 
 const packageJson = {
@@ -87,6 +134,7 @@ const manualMultipleComponentsConfig = [
     entry: "src/componentA.js",
     outDir: "dist/client",
     ssr: true,
+    ssrEntryFileName: "componentA-ssr",
   }),
 ];
 
@@ -122,6 +170,28 @@ describe("infer components", () => {
     expect(JSON.stringify(inferredComponents)).toEqual(
       JSON.stringify(manualMultipleComponentsConfig),
     );
+  });
+  it("generates the SSR entry filename from the declared ssr export", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    const inferredComponents = inferComponents(multipleComponentsPackageJson);
+    const generated = await collectGeneratedSsrFiles(inferredComponents);
+    // The `./componentA/ssr` export declares `./dist/server/componentA-ssr.js`,
+    // so the generated renderer entry (and its types) must use that basename.
+    expect(generated).toContain(
+      path.resolve("dist/server", "componentA-ssr.js"),
+    );
+    expect(generated).toContain(
+      path.resolve("dist/server", "componentA-ssr.d.ts"),
+    );
+    // and must NOT fall back to the hardcoded default that would collide.
+    expect(generated).not.toContain(path.resolve("dist/server", "ssr.js"));
+  });
+  it("keeps the default 'ssr' entry filename for single components", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    const inferredComponents = inferComponents(ssrPackageJson);
+    const generated = await collectGeneratedSsrFiles(inferredComponents);
+    expect(generated).toContain(path.resolve("dist/server", "ssr.js"));
+    expect(generated).toContain(path.resolve("dist/server", "ssr.d.ts"));
   });
   it("returns null if no exports are found", () => {
     const inferredComponents = inferComponents({ exports: {} });

--- a/packages/build/src/inferComponents.ts
+++ b/packages/build/src/inferComponents.ts
@@ -73,6 +73,11 @@ export const inferComponents = (packageJson: unknown): Options[] => {
       }
       const ssrOutDir = path.dirname(ssrPath);
       config.ssrOutDir = path.normalize(ssrOutDir);
+      // The declared ssr export (e.g. "./dist/server/button-ssr.js") dictates the
+      // basename of the generated renderer entry file ("button-ssr"). Threading it
+      // through keeps the generated file matching the exported path and avoids
+      // collisions when several SSR components share one ssrOutDir.
+      config.ssrEntryFileName = path.basename(ssrPath, path.extname(ssrPath));
 
       const ssrSveltePath = ssrExport?.["svelte"];
       if (typeof ssrSveltePath === "string") {

--- a/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.test.ts
+++ b/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.test.ts
@@ -95,6 +95,38 @@ describe("pluginGenerateSsrEntry", () => {
     );
   });
 
+  test("uses a custom entry filename when provided", async () => {
+    const plugin = pluginGenerateSsrEntry({
+      entryFileName: "button-ssr",
+    }) as {
+      writeBundle: FunctionPluginHooks["writeBundle"];
+    };
+
+    const mockContext = {
+      error: vi.fn(),
+    } as unknown as PluginContext;
+
+    const outputOptions: NormalizedOutputOptions = {
+      dir: "dist/server",
+    } as NormalizedOutputOptions;
+
+    plugin.writeBundle.call(mockContext, outputOptions, outputBundle);
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/button-ssr.js"),
+      expect.any(String),
+    );
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/button-ssr.d.ts"),
+      expect.any(String),
+    );
+    // must not fall back to the default filename that would collide
+    expect(mockFs.writeFile).not.toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/ssr.js"),
+      expect.any(String),
+    );
+  });
+
   test("throws error when no output directory is provided", async () => {
     const plugin = pluginGenerateSsrEntry({}) as {
       writeBundle: FunctionPluginHooks["writeBundle"];

--- a/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts
+++ b/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts
@@ -2,11 +2,18 @@ import fs from "fs/promises";
 import path from "path";
 import type { Plugin, NormalizedOutputOptions, PluginContext } from "rolldown";
 
-const ENTRY_FILE_NAME = "ssr";
+const DEFAULT_ENTRY_FILE_NAME = "ssr";
 
 interface GenerateSsrEntryPluginOptions {
   serverImportPath?: string;
   clientImportPath?: string;
+  /**
+   * The basename (without extension) of the generated SSR renderer entry file.
+   * Defaults to "ssr", producing 'ssr.js' / 'ssr.d.ts'. When multiple SSR
+   * components share an output directory this must be unique per component
+   * (e.g. "button-ssr") so the generated entries do not overwrite each other.
+   */
+  entryFileName?: string;
 }
 
 /**
@@ -20,6 +27,7 @@ export function pluginGenerateSsrEntry(
   const {
     serverImportPath = "./index.js",
     clientImportPath = "../client/index.js",
+    entryFileName = DEFAULT_ENTRY_FILE_NAME,
   } = options;
 
   return {
@@ -38,11 +46,11 @@ export function pluginGenerateSsrEntry(
 
       const ssrFilePath = path.resolve(
         outputOptions.dir,
-        `${ENTRY_FILE_NAME}.js`,
+        `${entryFileName}.js`,
       );
       const ssrTypesFilePath = path.resolve(
         outputOptions.dir,
-        `${ENTRY_FILE_NAME}.d.ts`,
+        `${entryFileName}.d.ts`,
       );
 
       const content = `import { SvelteCustomElementRenderer } from '@svebcomponents/ssr';

--- a/packages/ssr/src/lib/tsdown/svebcomponentsSsrConfig.ts
+++ b/packages/ssr/src/lib/tsdown/svebcomponentsSsrConfig.ts
@@ -25,6 +25,12 @@ interface SvebcomponentsSsrOptions {
    * Import path from the generated SSR renderer entrypoint to the client component module.
    */
   clientImportPath?: string;
+  /**
+   * The basename (without extension) of the generated SSR renderer entry file.
+   * Defaults to "ssr". Must be unique per component when several SSR components
+   * share an output directory (e.g. "button-ssr").
+   */
+  ssrEntryFileName?: string;
 }
 
 const createSsrTsdownConfig = ({
@@ -33,6 +39,7 @@ const createSsrTsdownConfig = ({
   externalSvelte = false,
   serverImportPath,
   clientImportPath,
+  ssrEntryFileName,
 }: SvebcomponentsSsrOptions) =>
   ({
     entry,
@@ -52,6 +59,9 @@ const createSsrTsdownConfig = ({
       pluginGenerateSsrEntry({
         ...(serverImportPath !== undefined ? { serverImportPath } : {}),
         ...(clientImportPath !== undefined ? { clientImportPath } : {}),
+        ...(ssrEntryFileName !== undefined
+          ? { entryFileName: ssrEntryFileName }
+          : {}),
       }),
     ],
   }) satisfies Options;


### PR DESCRIPTION
## Problem

`pluginGenerateSsrEntry` hardcoded the generated renderer entry filename to `ssr`, so every SSR build wrote `<ssrOutDir>/ssr.js` / `ssr.d.ts` regardless of the declared package export. Consequences:

1. The build README's multi-component example declares `"./button/ssr": { "default": "./dist/server/button-ssr.js" }` — a file the build never generated, so following the docs produced a package with a dangling export.
2. Two SSR components sharing one `ssrOutDir` overwrote each other's `ssr.js`/`ssr.d.ts`.

`inferComponents.test.ts` didn't catch this because it only compared config objects via `JSON.stringify`, which drops the plugin closures where the filename lives.

## Fix

- `inferComponents` derives the entry basename from the declared ssr export path (`./dist/server/button-ssr.js` → `button-ssr`) and passes it through.
- New `ssrEntryFileName` option on `DefineConfigOptions` (default `"ssr"`), forwarded through `svebcomponentsSsr(...)` into `pluginGenerateSsrEntry` (as `entryFileName`) for both the standalone and Svelte-aware SSR builds. Single-component packages and the existing e2e packages are unchanged.
- `serverImportPath`/`clientImportPath` were already derived from the entry basename in `defineConfig`, so named entries import the correct compiled component (verified: generated entry imports `./button.js` / `../client/button.js`).
- The generated `.d.ts` uses the same basename.
- The README multi-component example is now literally correct as written — no doc change needed.

## Verification

- `pnpm -F @svebcomponents/build test` — 14 tests pass, including two new tests that drive the generated plugin's `writeBundle` and assert the written paths are `dist/server/componentA-ssr.js` / `.d.ts` for the multi-component package.json (and that the colliding default `ssr.js` is NOT written), plus the default `ssr.js` case for single components.
- `pnpm -F @svebcomponents/ssr test` — 51 tests pass, including a new `pluginGenerateSsrEntry` test for a custom `entryFileName`.
- `pnpm build && pnpm test` from root — all 10 build tasks and 17 test tasks pass (branch rebased onto latest `main`, includes #67–#70).
- End-to-end proof: built a scratch workspace package mimicking the README multi-component example (exports `.`, `./button`, `./button/ssr` → `dist/server/button-ssr.js` with `svelte` conditions) using the real `svebcomponents` CLI. The build produced `dist/server/button-ssr.js`, `dist/server/button-ssr.d.ts`, `dist/server-svelte/button-ssr.js`, and `dist/server-svelte/button-ssr.d.ts`, exactly matching the declared exports, with correct imports (`./button.js`, `../client/button.js`). Scratch package removed before commit.

Changeset included: `@svebcomponents/build` patch + `@svebcomponents/ssr` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d