### PR TITLE
fix(ssr,build): drop test/build tools from runtime dependencies

### DIFF
--- a/.changeset/fix-runtime-dependencies.md
+++ b/.changeset/fix-runtime-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@svebcomponents/ssr": patch
+"@svebcomponents/build": patch
+---
+
+Drop test and build tooling from runtime dependencies: `vitest`, `rolldown`, `typescript`, and `tslib` are no longer installed when consuming `@svebcomponents/ssr`, and `typescript`/`tslib` are no longer installed when consuming `@svebcomponents/build`. These were only used for tests, type-only imports, or package builds and are now devDependencies (or removed entirely).

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -38,6 +38,7 @@
     "@svebcomponents/typescript-config": "workspace:*",
     "@types/node": "catalog:",
     "svelte": "catalog:",
+    "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
     "rolldown": "catalog:"
@@ -46,8 +47,6 @@
     "@svebcomponents/auto-options": "workspace:*",
     "@svebcomponents/ssr": "workspace:*",
     "rollup-plugin-svelte": "catalog:",
-    "tslib": "catalog:",
-    "typescript": "catalog:",
     "unconfig": "catalog:",
     "tsdown": "catalog:"
   },

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -51,23 +51,22 @@
     "@sveltejs/package": "catalog:",
     "@types/node": "catalog:",
     "publint": "catalog:",
+    "rolldown": "catalog:",
     "tsdown": "catalog:",
     "svelte": "catalog:",
     "svelte-check": "catalog:",
-    "vite": "catalog:"
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
   },
   "dependencies": {
     "@svebcomponents/utils": "workspace:*",
     "@lit-labs/ssr": "catalog:",
     "@lit-labs/ssr-dom-shim": "catalog:",
-    "typescript": "catalog:",
-    "tslib": "catalog:",
-    "vitest": "catalog:",
     "rollup-plugin-svelte": "catalog:",
     "zimmerframe": "catalog:",
     "magic-string": "catalog:",
-    "esm-env": "catalog:",
-    "rolldown": "catalog:"
+    "esm-env": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ catalogs:
     tsdown:
       specifier: 0.15.12
       version: 0.15.12
-    tslib:
-      specifier: 2.8.1
-      version: 2.8.1
     turbo:
       specifier: 2.5.2
       version: 2.5.2
@@ -395,12 +392,6 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.12(publint@0.3.21)(typescript@5.8.3)
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      typescript:
-        specifier: 'catalog:'
-        version: 5.8.3
       unconfig:
         specifier: 'catalog:'
         version: 7.3.2
@@ -423,6 +414,9 @@ importers:
       svelte:
         specifier: 'catalog:'
         version: 5.28.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
       vite:
         specifier: 'catalog:'
         version: 7.0.6(@types/node@22.14.1)(jiti@2.5.1)(yaml@2.9.0)
@@ -447,21 +441,9 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.17
-      rolldown:
-        specifier: 'catalog:'
-        version: 1.0.0-beta.29
       rollup-plugin-svelte:
         specifier: 'catalog:'
         version: 7.2.2(rollup@4.40.0)(svelte@5.28.2)
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
-      typescript:
-        specifier: 'catalog:'
-        version: 5.8.3
-      vitest:
-        specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.14.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(yaml@2.9.0)
       zimmerframe:
         specifier: 'catalog:'
         version: 1.1.2
@@ -484,6 +466,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.21
+      rolldown:
+        specifier: 'catalog:'
+        version: 1.0.0-beta.29
       svelte:
         specifier: 'catalog:'
         version: 5.28.2
@@ -493,9 +478,15 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.12(publint@0.3.21)(typescript@5.8.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.3
       vite:
         specifier: 'catalog:'
         version: 7.0.6(@types/node@22.14.1)(jiti@2.5.1)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@22.14.1)(@vitest/browser@3.2.4)(jiti@2.5.1)(yaml@2.9.0)
 
   packages/utils:
     devDependencies:
@@ -8328,7 +8319,8 @@ snapshots:
       - supports-color
       - vue-tsc
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   turbo-darwin-64@2.5.2:
     optional: true


### PR DESCRIPTION
## Problem

`@svebcomponents/ssr` declared `vitest`, `rolldown`, `typescript`, and `tslib` as runtime `dependencies`, so every consumer downloaded a test framework and a bundler. `@svebcomponents/build` likewise declared `typescript` and `tslib` as dependencies it never imports.

## What was verified per dependency

Each dependency was grepped against the shipped (non-test) source before being touched.

### @svebcomponents/ssr

| Dependency | Usage found | Action |
| --- | --- | --- |
| `vitest` | only `*.test.ts` files | moved to devDependencies |
| `rolldown` | `import type {...}` only, in `src/lib/rollup/*` | moved to devDependencies (type-only imports need no runtime dep) |
| `typescript` | no imports (only `@typescript-eslint` disable comments) | moved to devDependencies (used by `svelte-check`) |
| `tslib` | no references at all | removed |
| `@svebcomponents/utils` | `src/lib/vite/Server.svelte` | kept |
| `@lit-labs/ssr` | `runtime/types.ts`, `runtime/svelteCustomElementRenderer.ts`, `runtime/installShim.ts`, `vite/Server.svelte` | kept |
| `@lit-labs/ssr-dom-shim` | `runtime/installShim.ts` | kept |
| `esm-env` | `vite/CustomElementWrapper.svelte` | kept |
| `magic-string` | `vite/vitePluginSvebcomponentsSsr.ts` | kept |
| `zimmerframe` | `vite/vitePluginSvebcomponentsSsr.ts` | kept |
| `rollup-plugin-svelte` | `tsdown/svebcomponentsSsrConfig.ts` | kept |

### @svebcomponents/build

| Dependency | Usage found | Action |
| --- | --- | --- |
| `typescript` | no imports; needed for `tsc` build/check scripts | moved to devDependencies |
| `tslib` | no references at all | removed |
| `unconfig`, `tsdown`, `rollup-plugin-svelte`, `@svebcomponents/auto-options`, `@svebcomponents/ssr` | imported by `src/cli.ts` / `src/svebcomponentConfig.ts` / `src/index.ts` | kept |

## Verification

- `pnpm install` — lockfile updated, committed
- `pnpm build` — 10/10 tasks successful
- `pnpm test` — 17/17 tasks successful (all unit + e2e suites pass)
- `pnpm -F @svebcomponents/ssr exec publint` — "All good!", no new errors
- Changeset added: `.changeset/fix-runtime-dependencies.md` (patch for both packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d