### PR TITLE
docs(ssr): align security and limitation statements with implemented escaping

### DIFF
--- a/.changeset/ssr-docs-security-limitations.md
+++ b/.changeset/ssr-docs-security-limitations.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+docs: make SSR security/limitations statements precise and current

--- a/apps/docs/src/content/docs/core-concepts/ssr.mdx
+++ b/apps/docs/src/content/docs/core-concepts/ssr.mdx
@@ -4,8 +4,12 @@ description: How experimental server rendering works for Svelte-built custom ele
 ---
 
 :::danger
-Svebcomponents SSR is experimental, has not been hardened against injection
-attacks, and is not recommended for production use.
+Svebcomponents SSR is experimental and not recommended for production use.
+Attribute values/names and tag names are validated and escaped through
+Svelte's own SSR serializer, and this is covered by XSS regression tests, but
+the package has not had an independent security audit, and shadow-root
+content rendered via `{@html}` relies on the renderer's escaping. Avoid
+untrusted content in production.
 :::
 
 Browsers know how to instantiate custom elements. A server renderer usually

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -4,7 +4,7 @@ Browsers know how to instantiate custom elements, but server renderers usually o
 
 The design is modeled after Lit's server-side rendering system: custom elements are rendered by `ElementRenderer` classes, and the server uses declarative shadow DOM to serialize the rendered shadow root.
 
-This package is still experimental. It is useful for exploration and integration tests, but the runtime API and generated output may still change. It has not yet been hardened against XSS or other injection attacks, so do not use it with untrusted content in production.
+This package is still experimental. It is useful for exploration and integration tests, but the runtime API and generated output may still change. Attribute values/names and tag names are validated and escaped through Svelte's own SSR serializer, and this is covered by XSS regression tests, but the package has not had an independent security audit, and shadow-root content rendered via `{@html}` relies on the renderer's escaping. Treat it as experimental and avoid untrusted content in production.
 
 ## What It Provides
 
@@ -130,8 +130,7 @@ The plugin also rewrites plain `slot` attributes inside custom elements to sprea
 ## Current Limitations
 
 - This package is experimental and not recommended for production yet.
-- The generated HTML and shadow DOM output have not yet been audited or hardened against XSS.
+- Attribute values/names and tag names are validated/escaped via Svelte's SSR serializer and covered by XSS regression tests, but the generated HTML and shadow DOM output have not had an independent security audit.
 - Custom element tags are detected by the presence of a dash in the tag name.
 - The consuming app must import the browser custom element module and register the matching SSR renderer.
-- Server-side attribute rendering is still incomplete.
 - The Vite plugin currently transforms Svelte files and injects a Svelte wrapper component.


### PR DESCRIPTION
## Problem

Two audited doc issues (D2 + D3):

- **D2 — inconsistent/stale security posture.** The docs danger box (`apps/docs/src/content/docs/core-concepts/ssr.mdx`) said SSR "has not been hardened against injection attacks", and `packages/ssr/README.md` said it "has not yet been hardened against XSS or other injection attacks" and that the output "have not yet been audited or hardened against XSS". These blanket claims predate #64, which added attribute-value escaping via Svelte's SSR serializer (`attr`), attribute-name validation, custom-element tag-name validation, and three dedicated XSS regression e2e tests (`e2e/ssr/test/server/render.test.ts`).
- **D3 — stale limitation.** The README's Current Limitations still listed "Server-side attribute rendering is still incomplete", but host attributes, reflected props, and boolean attribute formatting were implemented in #64 and are covered by tests.

## Fix

Docs only — make the caveats precise without weakening them:

- Rewrite the security statements in both the README intro and the docs danger box with consistent wording: escaping/validation is implemented and covered by XSS regression tests, but the package has not had an independent security audit, and shadow-root content rendered via `{@html}` relies on the renderer's escaping. The "experimental, not recommended for production, avoid untrusted content" stance is kept.
- Update the README's Current Limitations audit bullet to the same precise wording.
- Remove the stale "Server-side attribute rendering is still incomplete" bullet.
- Add a `@svebcomponents/ssr` patch changeset.

## Before / after wording

| Location | Before | After |
| --- | --- | --- |
| README intro | "It has not yet been hardened against XSS or other injection attacks, so do not use it with untrusted content in production." | "Attribute values/names and tag names are validated and escaped through Svelte's own SSR serializer, and this is covered by XSS regression tests, but the package has not had an independent security audit, and shadow-root content rendered via `{@html}` relies on the renderer's escaping. Treat it as experimental and avoid untrusted content in production." |
| README limitations | "The generated HTML and shadow DOM output have not yet been audited or hardened against XSS." | "Attribute values/names and tag names are validated/escaped via Svelte's SSR serializer and covered by XSS regression tests, but the generated HTML and shadow DOM output have not had an independent security audit." |
| README limitations | "Server-side attribute rendering is still incomplete." | (removed — implemented in #64) |
| Docs danger box | "experimental, has not been hardened against injection attacks, and is not recommended for production use" | Same precise wording as the README intro. |

## Verification

- `pnpm -F @svebcomponents/ssr build` passes
- `pnpm -F @svebcomponents/docs build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d