### PR TITLE
chore: remove stale template submodule references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: install pnpm
         uses: pnpm/action-setup@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "template"]
-	path = template
-	url = https://github.com/svebcomponents/template

--- a/package.json
+++ b/package.json
@@ -26,10 +26,5 @@
       "esbuild",
       "svelte-preprocess"
     ]
-  },
-  "overrides": {
-    "@svebcomponents/build": "workspace:*",
-    "@svebcomponents/ssr": "workspace:*",
-    "@svebcomponents/example-component": "workspace:*"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "packageRules": [
-    {
-      "matchDepTypes": ["pnpm.catalog.template"],
-      "enabled": false
-    }
-  ]
+  "extends": ["config:recommended"]
 }


### PR DESCRIPTION
## Problem

The `template` submodule was removed from the tree a while ago, but stale references to it remained:

- `.gitmodules` still declared a `template` submodule, yet there is no gitlink in the tree (`git submodule status` prints nothing and `template/` does not exist)
- both `.github/workflows/ci.yml` and `.github/workflows/release.yml` checked out with `submodules: true`, even though there is nothing to check out
- `renovate.json` disabled updates for `matchDepTypes: ["pnpm.catalog.template"]`, but no `template` catalog exists in `pnpm-workspace.yaml`
- root `package.json` had an `overrides` block pinning `@svebcomponents/build`, `@svebcomponents/ssr`, and `@svebcomponents/example-component` (the latter is not a workspace package here — it lives in the separate template repo)

## Fix

- Delete `.gitmodules`
- Remove `submodules: true` from the checkout steps in both workflows (checkout `with:` blocks only; no other workflow changes)
- Remove the `pnpm.catalog.template` packageRule from `renovate.json` (and the now-empty `packageRules` key)
- Remove the entire stale `overrides` block from root `package.json`

## Overrides investigation

Before removing the overrides block, I verified it is completely inert:

1. pnpm only honors overrides declared under the `pnpm.overrides` key in the root `package.json`. This block was the npm-style **top-level** `overrides` key, which pnpm ignores — consistent with the committed `pnpm-lock.yaml` containing no `overrides:` section at all.
2. Empirically: `pnpm install --lockfile-only` produces a **byte-identical** `pnpm-lock.yaml` with and without the block (verified via `diff` against a saved baseline). So even the `@svebcomponents/build`/`@svebcomponents/ssr` entries have no effect on workspace resolution, and all three entries were safe to drop. (The e2e packages already depend on `build`/`ssr` via `workspace:*` directly.)

No lockfile changes resulted, so none are committed.

## Verification

- `pnpm install` — clean, lockfile unchanged
- `pnpm build` — 10/10 tasks successful
- `pnpm test` — 17/17 tasks successful
- `git submodule status` — empty (clean)

No changeset: repo infrastructure only, no published package affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)