### PR TITLE
fix(build): remove conflicting peer dependency on @svebcomponents/ssr

### DIFF
--- a/.changeset/fix-duplicate-ssr-dependency.md
+++ b/.changeset/fix-duplicate-ssr-dependency.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/build": patch
+---
+
+Remove conflicting peerDependency on `@svebcomponents/ssr`, keeping only the regular workspace dependency since it is imported directly and unconditionally.

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -29,9 +29,6 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "peerDependencies": {
-    "@svebcomponents/ssr": "^0.0.7"
-  },
   "devDependencies": {
     "@svebcomponents/eslint-config": "workspace:*",
     "@svebcomponents/prettier-config": "workspace:*",


### PR DESCRIPTION
## Problem

`packages/build/package.json` listed `@svebcomponents/ssr` **both** as a peerDependency (`"^0.0.7"`) and as a regular dependency (`"workspace:*"`). Package managers resolve this ambiguously, and the pinned peer range goes stale on every ssr version bump (the changesets config uses `updateInternalDependencies: "patch"`). Since the build CLI imports `@svebcomponents/ssr/tsdown` directly and unconditionally (`packages/build/src/index.ts` line 1), a regular dependency is correct.

## Fix

- Removed the `peerDependencies` entry for `@svebcomponents/ssr` from `packages/build/package.json`, keeping the `dependencies` entry (`workspace:*`).
- Added changeset `.changeset/fix-duplicate-ssr-dependency.md` (`@svebcomponents/build`: patch).
- Lockfile: no change needed — pnpm never recorded the redundant peer entry for the importer, so `pnpm install` reports "Lockfile is up to date" / "Already up to date" after the removal.

## Verification

- `pnpm install` — clean, no peer-resolution warnings for `@svebcomponents/build` (only the pre-existing unrelated "Ignored build scripts: sharp" notice).
- `pnpm build` — 10/10 tasks successful.
- `pnpm test` — 17/17 tasks successful, all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d