### PR TITLE
chore: move @changesets/cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "release": "turbo build && changeset publish"
   },
   "devDependencies": {
+    "@changesets/cli": "catalog:",
     "eslint": "catalog:",
     "prettier": "catalog:",
     "turbo": "catalog:"
@@ -25,9 +26,6 @@
       "esbuild",
       "svelte-preprocess"
     ]
-  },
-  "dependencies": {
-    "@changesets/cli": "catalog:"
   },
   "overrides": {
     "@svebcomponents/build": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,11 +115,10 @@ catalogs:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       '@changesets/cli':
         specifier: 'catalog:'
         version: 2.29.3
-    devDependencies:
       eslint:
         specifier: 'catalog:'
         version: 9.30.1(jiti@2.5.1)


### PR DESCRIPTION
## Problem

Audit finding H2: `@changesets/cli` was listed under `dependencies` in the root `package.json`. It is a development/release tool, not a runtime dependency. Since the root package is private this was cosmetic, but misleading.

## Fix

- Moved `"@changesets/cli": "catalog:"` from `dependencies` into the existing `devDependencies` block (removing the now-empty `dependencies` block).
- Ran `pnpm install` to refresh `pnpm-lock.yaml` accordingly.

No changeset needed (private root package, no published package affected).

## Verification

- `pnpm build` from root: 10/10 tasks successful
- `pnpm test` from root: 17/17 tasks successful
- `pnpm exec changeset --version` still resolves: `2.29.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d