### PR TITLE
docs(ssr): document DOM-shim import-order requirement

### DIFF
--- a/.changeset/document-dom-shim-import-order.md
+++ b/.changeset/document-dom-shim-import-order.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+document DOM-shim import-order requirement

--- a/apps/docs/src/content/docs/core-concepts/ssr.mdx
+++ b/apps/docs/src/content/docs/core-concepts/ssr.mdx
@@ -75,6 +75,14 @@ import MyComponentRenderer from "my-component-package/ssr";
 ElementRendererRegistry.set("my-component", MyComponentRenderer);
 ```
 
+:::caution
+The `@svebcomponents/ssr` import must come first, before importing any
+custom-element package. It installs the server DOM shims as a side effect,
+and custom element packages call `customElements.define` at module scope, so
+importing the component module first crashes with `customElements is not
+defined` on the server.
+:::
+
 The registry tells the server which renderer belongs to
 `<my-component>`.
 

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -71,6 +71,8 @@ import MyComponentRenderer from "my-component-package/ssr";
 ElementRendererRegistry.set("my-component", MyComponentRenderer);
 ```
 
+> **Caution:** The `@svebcomponents/ssr` import must come first, before importing any custom-element package. Importing `@svebcomponents/ssr` installs the server DOM shims (`Element`, `HTMLElement`, `customElements`) as a side effect, and custom element packages call `customElements.define` at module scope. Importing the component module first crashes with `customElements is not defined` on the server.
+
 The app can then render Svelte markup containing the custom element:
 
 ```svelte


### PR DESCRIPTION
## Problem

`@svebcomponents/ssr` installs the server DOM shims (`Element`, `HTMLElement`, `customElements`) as an import side effect (`packages/ssr/src/lib/index.ts` imports `./runtime/installShim.js` first). A consumer that imports their component package — which calls `customElements.define` at module scope — before `@svebcomponents/ssr` crashes on the server with `customElements is not defined`. The docs' examples happen to use the right order but never state the requirement.

## Fix

Docs only:

- `packages/ssr/README.md`: caution paragraph after the renderer-registration example in the App-author Flow section.
- `apps/docs/src/content/docs/core-concepts/ssr.mdx`: matching Starlight `:::caution` block after the equivalent registration example.
- Changeset (`@svebcomponents/ssr`: patch) so the README update ships to npm.

## Verification

- `pnpm -F @svebcomponents/ssr build` passes
- `pnpm -F @svebcomponents/docs build` passes (the docs page renders the caution block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d