### PR TITLE
fix(build,utils,auto-options): publint compliance — types condition first, files field, publint in builds

### DIFF
--- a/.changeset/fix-publint-compliance.md
+++ b/.changeset/fix-publint-compliance.md
@@ -1,0 +1,7 @@
+---
+"@svebcomponents/build": patch
+"@svebcomponents/utils": patch
+"@svebcomponents/auto-options": patch
+---
+
+Fix publint compliance: put the `types` export condition first so TypeScript resolves declarations as published, add `files` fields so tarballs only ship `dist` (and `bin.js` for the build package), and run publint as part of every publishable package's build.

--- a/packages/auto-options/package.json
+++ b/packages/auto-options/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/auto-options"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "rm -rf dist && tsc && publint",
     "check": "tsc --noEmit",
     "lint": "pnpm /^lint:.*/",
     "lint:eslint": "eslint .",
@@ -39,6 +39,7 @@
     "@svebcomponents/typescript-config": "workspace:*",
     "@types/estree": "catalog:",
     "@types/node": "catalog:",
+    "publint": "catalog:",
     "rolldown": "catalog:",
     "svelte": "catalog:",
     "vitest": "catalog:",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsc",
+    "build": "tsc && publint",
     "check": "tsc --noEmit",
     "lint": "pnpm /^lint:.*/",
     "lint:eslint": "eslint .",
@@ -23,10 +23,16 @@
     "test": "vitest run",
     "test:dev": "vitest --watch"
   },
+  "files": [
+    "dist",
+    "!dist/**/*.test.*",
+    "!dist/**/*.spec.*",
+    "bin.js"
+  ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "peerDependencies": {
@@ -37,6 +43,7 @@
     "@svebcomponents/prettier-config": "workspace:*",
     "@svebcomponents/typescript-config": "workspace:*",
     "@types/node": "catalog:",
+    "publint": "catalog:",
     "svelte": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsc --watch",
-    "build": "tsc",
+    "build": "tsc && publint",
     "check": "tsc --noEmit",
     "lint": "pnpm /^lint:.*/",
     "lint:eslint": "eslint .",
@@ -18,16 +18,20 @@
     "fix:eslint": "eslint . --fix",
     "fix:format": "prettier --write ."
   },
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "devDependencies": {
     "@svebcomponents/eslint-config": "workspace:*",
     "@svebcomponents/prettier-config": "workspace:*",
     "@svebcomponents/typescript-config": "workspace:*",
+    "publint": "catalog:",
     "svelte": "catalog:",
     "typescript": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.14.1
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.21
       rolldown:
         specifier: 'catalog:'
         version: 1.0.0-beta.29
@@ -417,6 +420,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.14.1
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.21
       rolldown:
         specifier: 'catalog:'
         version: 1.0.0-beta.29
@@ -508,6 +514,9 @@ importers:
       '@svebcomponents/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.21
       svelte:
         specifier: 'catalog:'
         version: 5.28.2


### PR DESCRIPTION
## Problem

publint reported errors on `@svebcomponents/build`, and the same pattern existed in `@svebcomponents/utils`:

1. `pkg.exports["."].types` did not come first in the conditions object. Export conditions are order-sensitive, so TypeScript may fail to resolve declarations as published.
2. No `files` field — the published tarball included `src/`, compiled tests, and eslint/prettier configs.
3. Only the `ssr` package ran publint in its build; `build`, `utils`, and `auto-options` were never checked.

`@svebcomponents/auto-options` already had `types` first and a `files` field — it only needed publint wired into its build.

## Fix

- **`packages/build/package.json`**: `types` condition first; `"files": ["dist", "!dist/**/*.test.*", "!dist/**/*.spec.*", "bin.js"]` (`bin.js` is the stable CLI entry referenced by the `bin` field); `build` is now `tsc && publint`; `publint: catalog:` in devDependencies.
- **`packages/utils/package.json`**: `types` condition first; `"files": ["dist"]`; `build` is now `tsc && publint`; `publint: catalog:` in devDependencies.
- **`packages/auto-options/package.json`**: `build` is now `rm -rf dist && tsc && publint`; `publint: catalog:` in devDependencies (exports order and `files` were already correct).
- Lockfile updated, changeset added (patch for all three packages).

## Verification

- `pnpm build` from root: 10/10 tasks successful; publint prints `All good!` for build, utils, auto-options (and ssr as before).
- `pnpm test` from root: 17/17 tasks successful.
- `npm pack --dry-run` for `@svebcomponents/build` — tarball now contains only dist, bin.js, README, package.json:

```
npm notice 📦  @svebcomponents/build@0.0.8
npm notice Tarball Contents
npm notice 6.2kB README.md
npm notice 357B bin.js
npm notice 64B dist/cli.d.ts
npm notice 100B dist/cli.d.ts.map
npm notice 1.1kB dist/cli.js
npm notice 817B dist/index.d.ts
npm notice 472B dist/index.d.ts.map
npm notice 1.9kB dist/index.js
npm notice 159B dist/inferComponents.d.ts
npm notice 227B dist/inferComponents.d.ts.map
npm notice 2.6kB dist/inferComponents.js
npm notice 844B dist/svebcomponentConfig.d.ts
npm notice 331B dist/svebcomponentConfig.d.ts.map
npm notice 575B dist/svebcomponentConfig.js
npm notice 1.6kB package.json
npm notice total files: 15
```

- `npm pack --dry-run` for `@svebcomponents/utils`: README.md, dist/index.d.ts, dist/index.d.ts.map, dist/index.js, package.json (5 files).

Note: PR #78 adds an `engines` field to the same package.json files — different keys, so any rebase conflict is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d