### PR TITLE
fix(ssr): add types condition to wrapper component export

### DIFF
--- a/.changeset/fix-wrapper-export-types.md
+++ b/.changeset/fix-wrapper-export-types.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Add a `types` condition to the `./wrapper-component` export so TypeScript and svelte-check can resolve the wrapper component's types in consuming projects.

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -30,6 +30,7 @@
       "import": "./dist/index.js"
     },
     "./wrapper-component": {
+      "types": "./dist/vite/CustomElementWrapper.svelte.d.ts",
       "svelte": "./dist/vite/CustomElementWrapper.svelte"
     },
     "./vite": {


### PR DESCRIPTION
## Problem

The `./wrapper-component` export in `packages/ssr/package.json` exposed only a `svelte` condition:

```json
"./wrapper-component": {
  "svelte": "./dist/vite/CustomElementWrapper.svelte"
}
```

The Vite plugin injects `import CustomElementWrapper from '@svebcomponents/ssr/wrapper-component'` into consumer components, so:

- **No `types` condition** — `tsc`/`svelte-check` in consumer apps cannot resolve type declarations for the module (TS2307).
- **No `default` fallback** — any non-Svelte-aware resolution fails with an unresolvable import.

## Fix

`svelte-package` already emits `dist/vite/CustomElementWrapper.svelte.d.ts` (verified after `pnpm -F @svebcomponents/ssr build`). This PR wires it up as the `types` condition, listed first as required by resolvers:

```json
"./wrapper-component": {
  "types": "./dist/vite/CustomElementWrapper.svelte.d.ts",
  "svelte": "./dist/vite/CustomElementWrapper.svelte"
}
```

Includes a patch changeset for `@svebcomponents/ssr`.

### Why no `default` condition

The only runtime artifact for this export is a `.svelte` file — there is no compiled JS module `svelte-package` emits for it. Pointing `default` at the `.svelte` file would make non-Svelte tooling resolve to a file it cannot parse, trading a clear resolution error for a confusing parse error, and inventing a JS shim would add a build artifact nobody consumes. The export stays Svelte-tooling-only at runtime; the `types` condition fixes the actual observed breakage (type-checking in consumer apps).

## Verification

- `pnpm -F @svebcomponents/ssr build` — svelte-package + **publint: All good!**
- Full `pnpm build && pnpm test` from root — 10/10 build tasks, 17/17 test tasks pass (incl. `e2e/ssr`, which consumes the Vite plugin + wrapper: 2 test files, 6 tests passed).
- Type-resolution proof from `e2e/ssr`: a scratch `.ts` file with `import CustomElementWrapper from '@svebcomponents/ssr/wrapper-component'` type-checks with `tsc --noEmit --moduleResolution bundler`:
  - **before** this change: `error TS2307: Cannot find module '@svebcomponents/ssr/wrapper-component' or its corresponding type declarations`
  - **after**: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d