### PR TITLE
fix(ssr): escape slot names in vite transform codegen

### DIFF
--- a/.changeset/fix-slot-name-escaping.md
+++ b/.changeset/fix-slot-name-escaping.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Escape slot names via JSON.stringify in the vite plugin's slot attribute transform, preventing syntax errors from slot names containing quotes.

--- a/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.test.ts
+++ b/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.test.ts
@@ -151,3 +151,24 @@ describe("vitePluginSvebcomponentsSsr", () => {
     expect(output).toContain("<font-face></font-face>");
   });
 });
+
+describe("vitePluginSvebcomponentsSsr - slot attribute transform", () => {
+  test("transforms a plain slot attribute into the spread form", async () => {
+    const output = await transform(
+      `<my-widget><p slot="test">hi</p></my-widget>`,
+    );
+
+    expect(output).not.toBeNull();
+    expect(output).toContain(`{...{slot: "test"}}`);
+  });
+
+  test("safely escapes a slot name containing a single quote", async () => {
+    const output = await transform(
+      `<my-widget><p slot="it's">hi</p></my-widget>`,
+    );
+
+    expect(output).not.toBeNull();
+    // JSON.stringify escapes the single quote safely (no manual quoting injection)
+    expect(output).toContain(`{...{slot: ${JSON.stringify("it's")}}}`);
+  });
+});

--- a/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts
+++ b/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts
@@ -52,7 +52,7 @@ const transformSlotAttribute = (
 
   const slotValueAssignment =
     slotValue.type === "Text"
-      ? `'${slotValue.data}'`
+      ? JSON.stringify(slotValue.data)
       : `${slotValue.expression}`;
   // replace the plain attribute with a spread
   magicString.overwrite(


### PR DESCRIPTION
## Problem

In `packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts`, `transformSlotAttribute` interpolated slot-attribute text into generated code with manual single-quoting (`'${slotValue.data}'`). A slot name containing a single quote (e.g. `<p slot="it's">`) therefore produced a syntax error in the transformed component — a code-generation injection point (audit finding B10).

## Fix

- Use `JSON.stringify(slotValue.data)` for the `Text` case so slot names are always emitted as a syntactically valid, escaped string literal.
- Added `vitePluginSvebcomponentsSsr.test.ts` covering the slot transform: a plain slot name transforms to the spread form (`{...{slot: "test"}}`), and a slot name containing a single quote emits the JSON-escaped string. Tests are narrowly scoped to slot behavior to avoid overlapping with in-flight broader plugin tests.
- Added changeset `fix-slot-name-escaping.md` (`@svebcomponents/ssr`: patch).

## Verification

- `pnpm -F @svebcomponents/ssr build` — passes (svelte-package + publint all good)
- `pnpm -F @svebcomponents/ssr test` — 10 test files, 58 tests, all passing (including the 2 new slot tests)
- Full `pnpm build` — 10/10 tasks successful
- Full `pnpm test` — 17/17 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d