### PR TITLE
docs: fix stale examples and document test/changeset workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,25 @@ pnpm install
 ```bash
 pnpm build
 ```
+
+## Running Tests
+
+```bash
+pnpm test
+```
+
+The browser e2e tests use Playwright with Chromium. On first-time setup, install the browser binary:
+
+```bash
+pnpm --filter "@svebcomponents/e2e.basic" exec playwright install chromium
+```
+
+## Changesets
+
+If your change affects a published package, describe it with a changeset before opening a PR:
+
+```bash
+pnpm changeset
+```
+
+Follow the prompts to select the affected package(s) and describe the change; commit the generated file in `.changeset/` along with your change.

--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ the version-compatibility tradeoff.
 - [`@svebcomponents/auto-options`]
   - automatically generate type converter & attribute settings from your props leveraging the typescript AST
 - [`@svebcomponents/ssr`]
-  - allows you to build SSR-able web components via `auto-options`
+  - lets `@svebcomponents/build` produce a server-renderable build (via tsdown) alongside the browser one
   - render web components that provide an `ElementRenderer` in SvelteKit (or other vite based SSR frameworks)

--- a/apps/docs/src/content/docs/core-concepts/auto-options.mdx
+++ b/apps/docs/src/content/docs/core-concepts/auto-options.mdx
@@ -19,9 +19,10 @@ In Svelte 5, props usually live in `$props()`:
   interface Props {
     label: string;
     value: number;
+    featured: boolean;
   }
 
-  let { label, value }: Props = $props();
+  let { label, value, featured }: Props = $props();
 </script>
 ```
 
@@ -34,6 +35,7 @@ generates the equivalent custom element options:
     props: {
       label: { attribute: "label", reflect: true, type: "String" },
       value: { attribute: "value", reflect: true, type: "Number" },
+      featured: { attribute: "featured", reflect: true, type: "Boolean" },
     },
   }}
 />

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -6,7 +6,7 @@ description: Start from the Svebcomponents template and build your first Svelte 
 The recommended starting point is the official [template repo](https://github.com/svebcomponents/template):
 
 ```bash
-pnpx degit svebcomponents/template my-project
+pnpm dlx degit svebcomponents/template my-project
 cd my-project
 pnpm install
 pnpm dev


### PR DESCRIPTION
Fixes four audited documentation nits (D6):

1. **getting-started.mdx**: `pnpx degit ...` used the deprecated `pnpx` command — replaced with `pnpm dlx degit svebcomponents/template my-project`.
2. **core-concepts/auto-options.mdx**: the "Attribute Conversion" example used a `featured` attribute that didn't exist in the preceding `Props` interface — extended the interface example with `featured: boolean` (and its generated `Boolean` prop option) so the examples are consistent.
3. **README.md**: the `@svebcomponents/ssr` bullet claimed SSR-able builds happen "via `auto-options`" — reworded to attribute the server-renderable build to `@svebcomponents/build`/tsdown.
4. **CONTRIBUTING.md**: added short sections for running tests (`pnpm test`, plus first-time Playwright Chromium install) and the changesets workflow (`pnpm changeset` for changes to published packages).

No changeset: only root README, CONTRIBUTING, and the private docs app are touched — no published package content changes.

Verified with `pnpm -F @svebcomponents/docs build` (passes, 16 pages built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d