### PR TITLE
fix(ssr): keep non-style svelte:head content out of the shadow root

### DIFF
--- a/.changeset/fix-svelte-head-shadow.md
+++ b/.changeset/fix-svelte-head-shadow.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Keep non-style `<svelte:head>` content (such as `<title>` and `<meta>`) out of the rendered shadow root; only `<style>` and `<link rel="stylesheet">` tags are forwarded.

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -135,3 +135,4 @@ The plugin also rewrites plain `slot` attributes inside custom elements to sprea
 - The consuming app must import the browser custom element module and register the matching SSR renderer.
 - Server-side attribute rendering is still incomplete.
 - The Vite plugin currently transforms Svelte files and injects a Svelte wrapper component.
+- `<svelte:head>` content is not supported in SSR'd custom elements: only `<style>` and `<link rel="stylesheet">` tags from the component's server-rendered head output are forwarded into the shadow root; document metadata such as `<title>` or `<meta>` is dropped.

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
@@ -265,6 +265,61 @@ describe("SvelteCustomElementRenderer", () => {
     expect(shadowContent).toContain("<div>Test content</div>");
   });
 
+  test("renderShadow drops non-style svelte:head content from the shadow root", () => {
+    // Mirrors what Svelte's server render() emits in `head` for a component
+    // using <svelte:head> when compiled with css: "injected": hydration
+    // markers, document metadata, and the injected component style.
+    mockRender.mockReturnValue({
+      body: '<!--[--><div class="both svelte-abc">both content</div><!--]-->',
+      head: '<!--[--><meta name="description" content="desc"> <link rel="canonical" href="https://example.com"><!--]--><title>Page Title</title><style id="svelte-abc">.both.svelte-abc {color:blue;}</style>',
+      html: "",
+    });
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    const renderResult = renderer.renderShadow({} as RenderInfo);
+    assert(renderResult);
+    const shadowContent = Array.from(renderResult).join("");
+
+    expect(shadowContent).toContain(
+      '<style id="svelte-abc">.both.svelte-abc {color:blue;}</style>',
+    );
+    expect(shadowContent).toContain(
+      '<div class="both svelte-abc">both content</div>',
+    );
+    expect(shadowContent).not.toContain("<title>");
+    expect(shadowContent).not.toContain("<meta");
+    expect(shadowContent).not.toContain('rel="canonical"');
+  });
+
+  test("renderShadow keeps stylesheet links but drops other head links", () => {
+    mockRender.mockReturnValue({
+      body: "<div>content</div>",
+      head: '<link rel="stylesheet" href="/theme.css"><link rel="preconnect" href="https://example.com"><link rel="icon" href="/favicon.ico">',
+      html: "",
+    });
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    const renderResult = renderer.renderShadow({} as RenderInfo);
+    assert(renderResult);
+    const shadowContent = Array.from(renderResult).join("");
+
+    expect(shadowContent).toContain(
+      '<link rel="stylesheet" href="/theme.css">',
+    );
+    expect(shadowContent).not.toContain('rel="preconnect"');
+    expect(shadowContent).not.toContain('rel="icon"');
+  });
+
   test("handles empty render result", () => {
     mockRender.mockReturnValue({
       body: "",

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
@@ -12,6 +12,27 @@ import {
   type SvelteCustomElementPropDefinition,
 } from "./html.js";
 
+const headStyleTagRegex = /<style\b[^>]*>[\s\S]*?<\/style\s*>|<link\b[^>]*>/gi;
+const relAttributeRegex = /\brel\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>=]+))/i;
+
+const isStylesheetLink = (tag: string): boolean => {
+  const match = relAttributeRegex.exec(tag);
+  const rel = match?.[1] ?? match?.[2] ?? match?.[3] ?? "";
+  return rel.toLowerCase().split(/\s+/).includes("stylesheet");
+};
+
+/**
+ * Svelte's server `render()` emits both injected component styles and
+ * `<svelte:head>` content into `head`. Only style resources are valid inside
+ * a shadow root, so we forward `<style>` and `<link rel="stylesheet">` tags
+ * and drop document metadata such as `<title>`, `<meta>`, or non-stylesheet
+ * `<link>` tags.
+ */
+export const extractShadowStylesFromHead = (head: string): string =>
+  (head.match(headStyleTagRegex) ?? [])
+    .filter((tag) => !/^<link/i.test(tag) || isStylesheetLink(tag))
+    .join("");
+
 export interface SvelteClientCustomElement {
   new (): Omit<SvelteClientCustomElement, "new">;
   attributes: Record<string, string>;
@@ -74,7 +95,10 @@ export class SvelteCustomElementRenderer
     const { body, head } = render(this.svelteSsrComponent, {
       props: this.svelteClientCustomElement.$$d,
     });
-    yield head;
+    // With `css: "injected"`, component styles land in `head` alongside any
+    // `<svelte:head>` content. Forward only the style resources into the
+    // shadow root; everything else would be invalid there.
+    yield extractShadowStylesFromHead(head);
     yield body;
   }
 


### PR DESCRIPTION
## Problem (audit B9)

`SvelteCustomElementRenderer.renderShadow` yielded the full `head` string from Svelte's server `render()` into the declarative shadow root. Svelte puts `<svelte:head>` content into `head`, so anything a component author placed there (`<title>`, `<meta>`, `<link rel="canonical">`, ...) ended up *inside the element's shadow root* — invalid placement for document metadata. Style injection only worked by accident of this.

## Empirical findings

Compiled scratch components with the same options as the SSR build (`generate: "server"`, `css: "injected"`, Svelte 5.28.2) and inspected `render()` output:

- Component with `<style>`: styles land in `head` as `<style id="svelte-...">...</style>` — **not** in `body`. So `head` cannot simply be dropped without losing component styles.
- Component with `<svelte:head>`: `head` contains the metadata tags mixed with hydration comment markers, e.g. `<!--[--><meta name="description" content="desc"> <link rel="canonical" ...><!--]--><title>Page Title</title>`.
- Component with both: one `head` string containing metadata followed by the injected style tag.

## Fix

`renderShadow` now filters `head` to the tags that are valid style resources inside a shadow root — `<style>...</style>` and `<link rel="stylesheet">` (rel matched token-wise, so `rel="preload stylesheet"` also passes) — and drops everything else (`<title>`, `<meta>`, non-stylesheet `<link>`, hydration markers). Document order of kept tags is preserved.

- New exported helper `extractShadowStylesFromHead` in `packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts`
- README "Current Limitations" documents that `<svelte:head>` content is not supported in SSR'd custom elements
- Unit tests: existing style-forwarding test unchanged and passing; new tests cover dropping `<svelte:head>` metadata (using realistic Svelte head output) and keeping stylesheet links while dropping `preconnect`/`icon` links
- Changeset: `@svebcomponents/ssr` patch

## Verification

- `pnpm -F @svebcomponents/ssr build && pnpm -F @svebcomponents/ssr test` — 58/58 passing (13 renderer tests incl. 2 new)
- Full `pnpm build && pnpm test` from root — 17/17 tasks passing, including the e2e ssr strict-equality snapshot (`head: ""`) and browser tests
- End-to-end sanity check through the built renderer with a `<svelte:head>` + `<style>` component: shadow root output is `<style id="svelte-...">.box...{color:red;}</style><!--[--><div class="box ...">shadow content</div><!--]-->` — style kept, `<title>`/`<meta>` gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d