### PR TITLE
refactor(utils): remove dead TODO helper (S3 + D4)

### DIFF
--- a/.changeset/remove-todo-util.md
+++ b/.changeset/remove-todo-util.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/utils": patch
+---
+
+Remove the unused `TODO()` helper export and its README documentation. Nothing in the repo (or any published svebcomponents package) called it — it was dead code that only logged to the console. Strictly speaking, dropping an export is a breaking change, but the package is 0.x and the helper was documented as internal/experimental, so this ships as a patch.

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -42,9 +42,3 @@ camelizeKebabCase("favorite-number"); // "favoriteNumber"
 ```
 
 Used by `@svebcomponents/ssr` when mapping non-string kebab-case values to component properties during server rendering.
-
-### `TODO(description, ...args)`
-
-Logs a runtime TODO marker.
-
-This is currently used only inside experimental SSR code paths where behavior is intentionally incomplete.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -22,7 +22,3 @@ export const isKebabCase = (str: string) => /^([a-z])+(-[a-z]+)*$/.test(str);
  */
 export const camelizeKebabCase = (str: string) =>
   str.replace(/-./g, (x) => x[1]!.toUpperCase());
-
-export const TODO = (description: string, ...args: unknown[]) => {
-  console.log(`TODO: ${description}`, ...args);
-};


### PR DESCRIPTION
## Problem

**S3 — dead code shipped in a published package.** `packages/utils/src/index.ts` exported `TODO(description, ...args)`, a helper that just `console.log`s. Nothing in the repo calls it, yet it shipped in `@svebcomponents/utils`.

**D4 — README documents the dead code.** `packages/utils/README.md` had a `### TODO(description, ...args)` section claiming the helper is "currently used only inside experimental SSR code paths" — false; no SSR (or any) code path uses it.

## Grep evidence

Searching all source (excluding `dist/` and `node_modules/`) for calls to `TODO(`:

```
$ grep -rn "TODO(" packages/ e2e/ --exclude-dir=dist --exclude-dir=node_modules
packages/utils/README.md:46:### `TODO(description, ...args)`
```

The only hit is the README section documenting it. With code file extensions only (`*.ts`, `*.js`, `*.svelte`, `*.tsx`), grep finds zero matches. The only imports from `@svebcomponents/utils` anywhere are `kebabize`, `isKebabCase`, and `camelizeKebabCase`:

```
$ grep -rn "from ['\"]@svebcomponents/utils" packages/ e2e/ --exclude-dir=dist --exclude-dir=node_modules
packages/ssr/src/lib/vite/Server.svelte:3:  import { isKebabCase, camelizeKebabCase } from "@svebcomponents/utils";
packages/auto-options/src/inferProps.ts:9:import { kebabize } from "@svebcomponents/utils";
```

## Fix

- Delete the `TODO` export from `packages/utils/src/index.ts`
- Delete the `TODO` section from `packages/utils/README.md`
- Add `.changeset/remove-todo-util.md` (`@svebcomponents/utils`: patch). Removing an export is technically breaking, but the package is 0.x and the helper was documented as internal/experimental, so it ships as a patch.

The diff is intentionally limited to exactly the TODO removal so it rebases trivially with the in-flight `fix/b8-iskebabcase-digits` branch, which also touches `packages/utils/src/index.ts`.

## Verification

- `pnpm -F @svebcomponents/utils build` — passes
- `pnpm build` from root — 10/10 tasks successful
- `pnpm test` from root — 17/17 tasks successful (proves no package depended on the export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d