### PR TITLE
fix(ssr): implement removeAttribute and clean up setAttribute in renderer

### DIFF
--- a/.changeset/fix-renderer-setattribute.md
+++ b/.changeset/fix-renderer-setattribute.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Clean up `SvelteCustomElementRenderer.setAttribute` by removing the dead non-string branch (all callers honor the string contract; non-string values go through `setProperty`), and add a `removeAttribute` method that deletes the attribute from the internal SSR attribute map and notifies the client element via `attributeChangedCallback(name, oldValue, null)`, mirroring browser semantics.

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
@@ -90,7 +90,7 @@ describe("SvelteCustomElementRenderer", () => {
     );
   });
 
-  test("sets non-string attributes directly on $$d without calling attribute changed callback", () => {
+  test("removes attributes and notifies via attributeChangedCallback", () => {
     const mockElement = {
       attributes: {},
       attributeChangedCallback: vi.fn(),
@@ -105,11 +105,58 @@ describe("SvelteCustomElementRenderer", () => {
       tagName,
     );
 
-    const complexValue = { foo: "bar" };
-    renderer.setAttribute("test-prop", complexValue as unknown as string);
+    renderer.setAttribute("data-test", "value1");
+    renderer.setAttribute("aria-label", "value2");
+    renderer.removeAttribute("data-test");
 
-    assert("test-prop" in mockElement.$$d);
-    expect(mockElement.$$d["test-prop"]).toBe(complexValue);
+    expect(mockElement.attributeChangedCallback).toHaveBeenLastCalledWith(
+      "data-test",
+      "value1",
+      null,
+    );
+    expect(Array.from(renderer.renderAttributes())).toStrictEqual([
+      ' aria-label="value2"',
+    ]);
+  });
+
+  test("removes attributes case-insensitively", () => {
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: {},
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    renderer.setAttribute("data-test", "value1");
+    renderer.removeAttribute("DATA-TEST");
+
+    expect(Array.from(renderer.renderAttributes())).toStrictEqual([]);
+  });
+
+  test("removing an absent attribute is a no-op and does not notify", () => {
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: {},
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    renderer.removeAttribute("data-test");
+
     expect(mockElement.attributeChangedCallback).not.toHaveBeenCalled();
   });
 

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
@@ -17,8 +17,8 @@ export interface SvelteClientCustomElement {
   attributes: Record<string, string>;
   attributeChangedCallback: (
     name: string,
-    oldValue: string,
-    newValue: string,
+    oldValue: string | null,
+    newValue: string | null,
   ) => void;
   ["$$d"]: Record<string, unknown>;
   /**
@@ -49,14 +49,33 @@ export class SvelteCustomElementRenderer
   }
 
   override setAttribute(name: string, value: string) {
-    if (typeof value !== "string") {
-      this.svelteClientCustomElement.$$d[name] = value;
-      // maybe do something to reflect the prop to the attributes, perhaps 'this.$$me' does this out of the box for us?
-      return;
-    }
+    // All known callers honor the `value: string` contract: Lit's SSR
+    // pipeline stringifies attribute values before calling this, and our
+    // Server.svelte wrapper routes non-string values through `setProperty`.
     name = name.toLowerCase();
     this.ssrAttributes.set(name, value);
     this.svelteClientCustomElement.attributeChangedCallback(name, value, value);
+  }
+
+  /**
+   * Not part of Lit's `ElementRenderer` API (which never removes attributes),
+   * but mirrors the DOM's `Element.removeAttribute` so wrapper code can clear
+   * an attribute that was set earlier during rendering.
+   */
+  removeAttribute(name: string) {
+    name = name.toLowerCase();
+    const oldValue = this.ssrAttributes.get(name);
+    if (oldValue === undefined) {
+      // Mirrors browser behavior: removing an absent attribute is a no-op
+      // and does not fire attributeChangedCallback.
+      return;
+    }
+    this.ssrAttributes.delete(name);
+    this.svelteClientCustomElement.attributeChangedCallback(
+      name,
+      oldValue,
+      null,
+    );
   }
 
   override *renderAttributes(): RenderResult {


### PR DESCRIPTION
Fixes audited issue S4: dead/dubious branch in `SvelteCustomElementRenderer.setAttribute` and missing `removeAttribute` handling.

## Findings

- **The non-string `setAttribute` branch is dead for every known caller.** Lit's SSR pipeline (`@lit-labs/ssr` `render-value.js`) only ever calls `setAttribute` with strings: static attributes come from the parsed template, attribute parts pass `String(value ?? '')`, and boolean attribute parts pass `''`. Our own `Server.svelte` wrapper guards with `typeof value === "string"` and routes everything else through `setProperty` — which already stores into `$$d`, i.e. exactly what the dead branch tried to do. Deleting the branch therefore keeps Lit-contract callers safe; the speculative `$$me` comment and the unit test asserting the branch's behavior are removed with it.
- **`ElementRenderer` declares no `removeAttribute`.** Checked `@lit-labs/ssr@3.3.1` (`lib/element-renderer.d.ts` / `.js`): `removeAttribute` exists only on the ssr-dom-shim's `HTMLElement`, not on the renderer contract, and nothing in `@lit-labs/ssr` ever removes attributes. So the new method is a plain method (no `override`) that mirrors the DOM's `Element.removeAttribute` for wrapper callers.

## Changes

- `setAttribute`: removed the unreachable `typeof value !== "string"` branch; behavior for string values is unchanged.
- New `removeAttribute(name)`: lowercases the name, is a no-op without notification when the attribute is absent (browser semantics), otherwise deletes it from the internal `ssrAttributes` map and notifies the client element via `attributeChangedCallback(name, oldValue, null)` — Svelte's generated custom element converts a `null` new value to the cleared prop value.
- `SvelteClientCustomElement.attributeChangedCallback` typing widened to `string | null` for old/new values, matching the DOM spec and Lit's own typing.
- Tests: removed the non-string-branch test; added coverage for removal + notification, case-insensitive removal, and absent-attribute no-op.
- Changeset: `@svebcomponents/ssr` patch.

## Verification

- `pnpm -F @svebcomponents/ssr build` — clean, publint passes
- `pnpm -F @svebcomponents/ssr test` — 58 tests pass
- `pnpm -F @svebcomponents/ssr lint` — prettier + eslint clean
- `pnpm build && pnpm test` from root — all 17 tasks pass

Note: kept the diff away from the constructor/tagName area touched by #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d