### PR TITLE
test: assert plugin pipelines and drop global Map stub in registry tests

### DIFF
--- a/.changeset/fix-test-assertions.md
+++ b/.changeset/fix-test-assertions.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Export `createElementRendererRegistry` factory for creating isolated renderer registry instances (e.g. in tests), alongside the unchanged global `ElementRendererRegistry` accessor.

--- a/packages/build/src/inferComponents.test.ts
+++ b/packages/build/src/inferComponents.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, type MockedFunction, vi } from "vitest";
+import type { Options } from "tsdown";
 import { inferComponents } from "./inferComponents";
 import { defineConfig } from "./index.js";
 import fs from "node:fs";
@@ -90,38 +91,77 @@ const manualMultipleComponentsConfig = [
   }),
 ];
 
+/**
+ * Extracts the ordered plugin names of a tsdown `Options` entry.
+ * `JSON.stringify` drops the plugin objects (their hooks are functions), so
+ * plugin pipelines have to be asserted explicitly via their names.
+ */
+const pluginNames = (options: Options): string[] => {
+  const plugins = options.plugins;
+  expect(Array.isArray(plugins)).toBe(true);
+  return (plugins as { name: string }[]).map((plugin) => plugin.name);
+};
+
+const clientPipeline = ["svebcomponents:auto-options", "svelte"];
+const ssrPipeline = [
+  "svebcomponents:override-svelte-ssr-slot-implementation",
+  "svelte",
+  "svebcomponents:generate-ssr-entry",
+];
+
+/**
+ * Asserts that `inferred` matches `expected` both in its serializable fields
+ * (via JSON, which silently drops functions like plugin hooks) and in its
+ * plugin pipelines (via plugin names, which the JSON comparison cannot see).
+ */
+const expectConfigsToMatch = (
+  inferred: Options[],
+  expected: Options[],
+  expectedPipelines: string[][],
+) => {
+  // use `JSON.stringify` to compare the plain fields without comparing
+  // method references
+  expect(JSON.stringify(inferred)).toEqual(JSON.stringify(expected));
+  // additionally assert each config's plugin pipeline explicitly
+  expect(inferred).toHaveLength(expectedPipelines.length);
+  for (const [index, pipeline] of expectedPipelines.entries()) {
+    expect(pluginNames(inferred[index]!)).toEqual(pipeline);
+    expect(pluginNames(expected[index]!)).toEqual(pipeline);
+  }
+};
+
 describe("infer components", () => {
   it("parses components from package.json", () => {
     mockFs.existsSync.mockReturnValue(true);
     const inferredComponents = inferComponents(packageJson);
-    // use `JSON.stringify` to avoid comparing method references
-    expect(JSON.stringify(inferredComponents)).toEqual(
-      JSON.stringify(manualConfig),
-    );
+    expectConfigsToMatch(inferredComponents, manualConfig, [clientPipeline]);
   });
   it("parses SSR components from package.json", () => {
     mockFs.existsSync.mockReturnValue(true);
     const inferredComponents = inferComponents(ssrPackageJson);
-    // use `JSON.stringify` to avoid comparing method references
-    expect(JSON.stringify(inferredComponents)).toEqual(
-      JSON.stringify(manualSSRConfig),
-    );
+    expectConfigsToMatch(inferredComponents, manualSSRConfig, [
+      clientPipeline,
+      ssrPipeline,
+    ]);
   });
   it("parses Svelte conditional exports from package.json", () => {
     mockFs.existsSync.mockReturnValue(true);
     const inferredComponents = inferComponents(svelteConditionPackageJson);
-    // use `JSON.stringify` to avoid comparing method references
-    expect(JSON.stringify(inferredComponents)).toEqual(
-      JSON.stringify(manualSvelteConditionConfig),
-    );
+    expectConfigsToMatch(inferredComponents, manualSvelteConditionConfig, [
+      clientPipeline,
+      clientPipeline,
+      ssrPipeline,
+      ssrPipeline,
+    ]);
   });
   it("parses multiple components from package.json", () => {
     mockFs.existsSync.mockReturnValue(true);
     const inferredComponents = inferComponents(multipleComponentsPackageJson);
-    // use `JSON.stringify` to avoid comparing method references
-    expect(JSON.stringify(inferredComponents)).toEqual(
-      JSON.stringify(manualMultipleComponentsConfig),
-    );
+    expectConfigsToMatch(inferredComponents, manualMultipleComponentsConfig, [
+      clientPipeline,
+      clientPipeline,
+      ssrPipeline,
+    ]);
   });
   it("returns null if no exports are found", () => {
     const inferredComponents = inferComponents({ exports: {} });

--- a/packages/ssr/src/lib/runtime/rendererRegistry.test.ts
+++ b/packages/ssr/src/lib/runtime/rendererRegistry.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe, beforeEach, vi } from "vitest";
-import { ElementRendererRegistry } from "./rendererRegistry";
+import { createElementRendererRegistry } from "./rendererRegistry";
 import type { ElementRendererCtor } from "./types";
 
 const { mockCustomElements } = vi.hoisted(() => {
@@ -8,17 +8,6 @@ const { mockCustomElements } = vi.hoisted(() => {
     get: vi.fn(),
     set: vi.fn(),
   };
-
-  // ElementRendererRegistry uses a Map to store renderers, but since it is a private property, we can't clear it from the outside.
-  // So we stub "Map" with an AutoClearingMap that automatically clear itself before each test.
-  class AutoClearingMap extends Map {
-    constructor() {
-      super();
-      beforeEach(() => this.clear());
-    }
-  }
-
-  vi.stubGlobal("Map", AutoClearingMap);
 
   vi.stubGlobal("customElements", mockCustomElements);
 
@@ -29,8 +18,13 @@ const { mockCustomElements } = vi.hoisted(() => {
 });
 
 describe("ElementRendererRegistry", () => {
+  // Create a fresh registry instance for each test instead of relying on the
+  // shared global singleton, so tests don't leak state into one another.
+  let ElementRendererRegistry: ReturnType<typeof createElementRendererRegistry>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    ElementRendererRegistry = createElementRendererRegistry();
   });
 
   test("sets and gets renderer for element class", () => {

--- a/packages/ssr/src/lib/runtime/rendererRegistry.ts
+++ b/packages/ssr/src/lib/runtime/rendererRegistry.ts
@@ -57,3 +57,9 @@ if (!globalThis[REGISTRY_KEY]) {
 
 // Export a convenience accessor
 export const ElementRendererRegistry = globalThis[REGISTRY_KEY];
+
+// Export a factory for creating isolated registry instances, e.g. for tests
+// that need a fresh registry without mutating the shared global one.
+export function createElementRendererRegistry() {
+  return new _ElementRendererRegistry();
+}


### PR DESCRIPTION
## Problem

Two weak spots in the test suite (audit item S7):

1. **`packages/build/src/inferComponents.test.ts`** compared inferred configs against expected configs only via `JSON.stringify`. Plugin objects are made of functions, so serialization silently drops the entire `plugins` array — the most important part of each config was never asserted. A build that produced configs with missing, extra, or reordered plugins would still pass.
2. **`packages/ssr/src/lib/runtime/rendererRegistry.test.ts`** stubbed the global `Map` builtin with an auto-clearing subclass (`vi.stubGlobal("Map", AutoClearingMap)`) to reset the module-global registry between tests — mutating a JS builtin for the whole test file to work around the registry being global state.

## Approach

1. Added a `pluginNames` helper that extracts the ordered plugin names from a tsdown `Options` entry, plus an `expectConfigsToMatch` helper that keeps the JSON comparison for the plain fields and additionally asserts each config's plugin pipeline explicitly: `svebcomponents:auto-options` + `svelte` for client builds, and `svebcomponents:override-svelte-ssr-slot-implementation` + `svelte` + `svebcomponents:generate-ssr-entry` for SSR builds. Pipelines are asserted on both the inferred and the manually defined configs, for every entry of every test case.
2. Exported a `createElementRendererRegistry()` factory from `@svebcomponents/ssr` (the public global `ElementRendererRegistry` accessor is unchanged) and rewrote the registry tests to instantiate a fresh registry in `beforeEach` instead of stubbing `Map`. All existing tests are preserved, including the prototype-chain `has()` coverage from #67.

Changeset: `@svebcomponents/ssr` patch (the factory export ships); no bump for `@svebcomponents/build` since only its tests changed.

## Verification

- `pnpm -F @svebcomponents/build test` — 12 tests pass
- `pnpm -F @svebcomponents/ssr test` — 54 tests pass (registry tests run against both `src` and the packaged `.svelte-kit/__package__` output)
- `pnpm build && pnpm test` from root — 10 build tasks, 17 test tasks, all pass
- `pnpm lint` and prettier check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d