### PR TITLE
chore: make lint depend on dependency builds in turbo

### DIFF
--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -10,7 +10,11 @@
         "dist"
       ]
     },
-    "lint": {},
+    "lint": {
+      "dependsOn": [
+        "^build"
+      ]
+    },
     "fix": {},
     "check": {
       "dependsOn": [


### PR DESCRIPTION
## What

Adds `"dependsOn": ["^build"]` to the `lint` task in `turbo.jsonc`, matching `check`. (Audit finding H3.)

## Empirical findings

Verified from a clean state (no `dist` outputs anywhere) using turbo dry-runs and real lint runs:

- `pnpm turbo lint --dry-run` showed every `#lint` task with **zero dependencies** — no dependency builds run first.
- `pnpm lint` on the dist-less tree currently **exits 0**, so lint does not hard-fail today — but only because no enabled rule happens to consume the broken type info.
- Type information **is silently degraded**: the shared svelte eslint config uses `projectService: true`, and `packages/ssr/src/lib/vite/Server.svelte` imports from `@svebcomponents/utils`, whose types resolve via `dist/index.d.ts`. Probing with a type-aware rule (`@typescript-eslint/no-unsafe-call`) pre-build flags 3 errors (`Unsafe call of a(n) \`error\` type typed value`); after building `@svebcomponents/utils` the same probe passes. So lint results — and therefore turbo's lint cache — depend on build outputs that the task graph didn't declare.

Also reviewed `test`'s `dependsOn: ["build"]`: the `pnpm turbo test --dry-run` graph confirms each package's `test` depends on its own `build`, which depends on `^build`, so workspace deps are built transitively. No change needed.

`check` outputs: turbo emitted no warnings about missing `outputs` for `check` during any run, so it is left untouched per the audit guidance.

## Verification

- `pnpm turbo lint --dry-run` now shows each `#lint` depending on its workspace deps' `#build` tasks (e.g. `ssr#lint` → `utils#build`), mirroring `check`.
- `pnpm build` (10/10), `pnpm lint` (14/14), `pnpm check` (10/10), `pnpm test` (17/17) all pass.

No changeset (repo infrastructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d