### PR TITLE
fix(ssr): exclude spec-reserved names from custom element detection

### DIFF
--- a/.changeset/fix-reserved-svg-names.md
+++ b/.changeset/fix-reserved-svg-names.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Fix the Vite transform mistakenly wrapping spec-reserved SVG/MathML tag names (`font-face`, `font-face-src`, `font-face-uri`, `font-face-format`, `font-face-name`, `annotation-xml`, `color-profile`, `missing-glyph`) as custom elements just because they contain a dash. These names are explicitly excluded from valid custom element names by the HTML spec, and wrapping them corrupted otherwise-valid SVG/MathML markup.

--- a/packages/ssr/src/lib/runtime/html.test.ts
+++ b/packages/ssr/src/lib/runtime/html.test.ts
@@ -1,0 +1,38 @@
+import { expect, test, describe } from "vitest";
+import { isValidCustomElementTagName } from "./html";
+
+describe("isValidCustomElementTagName", () => {
+  test("accepts valid custom element tag names", () => {
+    expect(isValidCustomElementTagName("my-element")).toBe(true);
+    expect(isValidCustomElementTagName("x-foo-bar")).toBe(true);
+    expect(isValidCustomElementTagName("a-1")).toBe(true);
+  });
+
+  test("rejects tag names without a dash", () => {
+    expect(isValidCustomElementTagName("div")).toBe(false);
+    expect(isValidCustomElementTagName("myelement")).toBe(false);
+  });
+
+  test("rejects tag names starting with an uppercase letter or non-letter", () => {
+    expect(isValidCustomElementTagName("My-Element")).toBe(false);
+    expect(isValidCustomElementTagName("1-element")).toBe(false);
+    expect(isValidCustomElementTagName("-element")).toBe(false);
+  });
+
+  // @see https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+  test.each([
+    "annotation-xml",
+    "color-profile",
+    "font-face",
+    "font-face-src",
+    "font-face-uri",
+    "font-face-format",
+    "font-face-name",
+    "missing-glyph",
+  ])(
+    "rejects the spec-reserved SVG/MathML name %s despite matching the dash grammar",
+    (reservedName) => {
+      expect(isValidCustomElementTagName(reservedName)).toBe(false);
+    },
+  );
+});

--- a/packages/ssr/src/lib/runtime/html.ts
+++ b/packages/ssr/src/lib/runtime/html.ts
@@ -1,6 +1,8 @@
 // eslint-disable-next-line svelte/no-svelte-internal -- Reuse Svelte's SSR attribute serializer instead of maintaining our own escaping rules.
 import { attr } from "svelte/internal/server";
 
+export { isValidCustomElementTagName } from "../shared/customElementName.js";
+
 export const SvelteCustomElementPropType = {
   Array: "Array",
   Boolean: "Boolean",
@@ -19,16 +21,6 @@ export interface SvelteCustomElementPropDefinition {
 }
 
 const invalidAttributeNameCharsRegex = /[\s"'>/=]/;
-
-/**
- * ASCII subset of the HTML spec's PotentialCustomElementName grammar.
- * The wrapper only receives tag names produced from Svelte source, but this
- * keeps the raw SSR opening/closing tags from ever accepting tag-shaped input.
- *
- * @see https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
- */
-export const isValidCustomElementTagName = (tagName: string) =>
-  /^[a-z][.0-9_a-z-]*-[.0-9_a-z-]*$/.test(tagName);
 
 /**
  * Reject characters that cannot appear in HTML attribute names.

--- a/packages/ssr/src/lib/shared/customElementName.test.ts
+++ b/packages/ssr/src/lib/shared/customElementName.test.ts
@@ -1,0 +1,43 @@
+import { expect, test, describe } from "vitest";
+import {
+  mayBeCustomElementTagName,
+  isValidCustomElementTagName,
+} from "./customElementName";
+
+describe("mayBeCustomElementTagName", () => {
+  test("is true for any tag name containing a dash", () => {
+    expect(mayBeCustomElementTagName("my-element")).toBe(true);
+    expect(mayBeCustomElementTagName("font-face")).toBe(true);
+  });
+
+  test("is false for tag names without a dash", () => {
+    expect(mayBeCustomElementTagName("div")).toBe(false);
+    expect(mayBeCustomElementTagName("svg")).toBe(false);
+  });
+});
+
+describe("isValidCustomElementTagName", () => {
+  test("accepts valid custom element tag names", () => {
+    expect(isValidCustomElementTagName("my-element")).toBe(true);
+    expect(isValidCustomElementTagName("x-foo-bar")).toBe(true);
+  });
+
+  test("rejects names that don't match the PotentialCustomElementName grammar", () => {
+    expect(isValidCustomElementTagName("div")).toBe(false);
+    expect(isValidCustomElementTagName("My-Element")).toBe(false);
+  });
+
+  // @see https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+  test.each([
+    "annotation-xml",
+    "color-profile",
+    "font-face",
+    "font-face-src",
+    "font-face-uri",
+    "font-face-format",
+    "font-face-name",
+    "missing-glyph",
+  ])("rejects the spec-reserved SVG/MathML name %s", (reservedName) => {
+    expect(isValidCustomElementTagName(reservedName)).toBe(false);
+  });
+});

--- a/packages/ssr/src/lib/shared/customElementName.ts
+++ b/packages/ssr/src/lib/shared/customElementName.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure, dependency-free custom-element name predicates shared between the
+ * build-time Vite transform (`../vite/vitePluginSvebcomponentsSsr.ts`) and the
+ * SSR runtime (`../runtime/html.ts`).
+ *
+ * This module intentionally has zero imports so it can be pulled into the
+ * Vite plugin without dragging Svelte's runtime (e.g. `svelte/internal/server`)
+ * into the plugin's dependency graph.
+ */
+
+/**
+ * ASCII subset of the HTML spec's PotentialCustomElementName grammar.
+ *
+ * @see https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+ */
+const potentialCustomElementNameRegex = /^[a-z][.0-9_a-z-]*-[.0-9_a-z-]*$/;
+
+/**
+ * Names that match the PotentialCustomElementName grammar (they contain a
+ * hyphen) but are explicitly excluded from valid custom element names by the
+ * HTML spec, since they are reserved for SVG/MathML.
+ *
+ * @see https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+ */
+const reservedCustomElementNames = new Set([
+  "annotation-xml",
+  "color-profile",
+  "font-face",
+  "font-face-src",
+  "font-face-uri",
+  "font-face-format",
+  "font-face-name",
+  "missing-glyph",
+]);
+
+/**
+ * Cheap pre-check for whether a tag name could possibly be a custom element
+ * name. Intended as a fast path before calling `isValidCustomElementTagName`,
+ * which does the full (more expensive) validation.
+ */
+export const mayBeCustomElementTagName = (tagName: string) =>
+  tagName.includes("-");
+
+/**
+ * Full validation of the HTML spec's PotentialCustomElementName grammar,
+ * excluding the spec's reserved SVG/MathML names (e.g. `font-face`,
+ * `annotation-xml`) that would otherwise match the "has a dash" grammar.
+ *
+ * @see https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
+ */
+export const isValidCustomElementTagName = (tagName: string) =>
+  potentialCustomElementNameRegex.test(tagName) &&
+  !reservedCustomElementNames.has(tagName);

--- a/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.test.ts
+++ b/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.test.ts
@@ -113,4 +113,41 @@ describe("vitePluginSvebcomponentsSsr", () => {
     // nothing to transform => plugin returns null (no changes)
     expect(output).toBeNull();
   });
+
+  test("does not wrap <font-face> nested inside <svg>", async () => {
+    const output = await transform(`<svg><font-face></font-face></svg>`);
+
+    // Nothing to wrap, so the transform should be a no-op.
+    expect(output).toBeNull();
+  });
+
+  test("does not wrap other spec-reserved SVG/MathML names", async () => {
+    const output = await transform(
+      [
+        "<svg>",
+        "<font-face-src></font-face-src>",
+        "<font-face-uri></font-face-uri>",
+        "<font-face-format></font-face-format>",
+        "<font-face-name></font-face-name>",
+        "<missing-glyph></missing-glyph>",
+        "</svg>",
+        "<annotation-xml></annotation-xml>",
+        "<color-profile></color-profile>",
+      ].join(""),
+    );
+
+    expect(output).toBeNull();
+  });
+
+  test("still wraps a real custom element that is a sibling of a reserved SVG name", async () => {
+    const output = await transform(
+      `<svg><font-face></font-face></svg><my-element></my-element>`,
+    );
+
+    expect(output).not.toBeNull();
+    expect(output).toContain("CustomElementWrapper");
+    expect(output).toContain('_tagName="my-element"');
+    // The reserved name must not have been touched.
+    expect(output).toContain("<font-face></font-face>");
+  });
 });

--- a/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts
+++ b/packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts
@@ -3,6 +3,11 @@ import { parse, type AST } from "svelte/compiler";
 import { walk } from "zimmerframe";
 import MagicString from "magic-string";
 
+import {
+  mayBeCustomElementTagName,
+  isValidCustomElementTagName,
+} from "../shared/customElementName.js";
+
 const WRAPPER_COMPONENT_NAME = "CustomElementWrapper";
 const WRAPPER_SOURCE_PACKAGE = "@svebcomponents/ssr/wrapper-component";
 const WRAPPER_TAG_NAME_PROP = "_tagName";
@@ -97,7 +102,15 @@ function vitePluginSvebcomponentsSsr(): Plugin {
                 transformSlotAttribute(node, magicString);
               }
               let originalTagName: string | undefined;
-              if (node.name.includes("-")) {
+              // Cheap fast path first (avoids the regex for the vast
+              // majority of elements), then fully validate against the HTML
+              // spec's PotentialCustomElementName grammar so reserved
+              // SVG/MathML names like `font-face` or `annotation-xml` aren't
+              // mistaken for custom elements.
+              if (
+                mayBeCustomElementTagName(node.name) &&
+                isValidCustomElementTagName(node.name)
+              ) {
                 originalTagName = node.name;
                 state.webComponents.push(originalTagName);
 


### PR DESCRIPTION
## Problem

`packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.ts` detected custom elements to wrap with `CustomElementWrapper` purely by checking whether the tag name contained a dash (`node.name.includes("-")`). The HTML spec's [PotentialCustomElementName grammar](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) also matches this "has a dash" shape for a set of names that are explicitly *reserved* and excluded from being valid custom element names:

`annotation-xml`, `color-profile`, `font-face`, `font-face-src`, `font-face-uri`, `font-face-format`, `font-face-name`, `missing-glyph`

These are real SVG/MathML element names. The transform would wrap them in `CustomElementWrapper`, corrupting otherwise-valid SVG/MathML documents (e.g. an `<svg>` containing a `<font-face>` definition).

Separately, `packages/ssr/src/lib/runtime/html.ts` already exported an `isValidCustomElementTagName` implementing the PotentialCustomElementName grammar (used by the SSR wrapper component to validate tag names before writing them into raw HTML), but it didn't exclude the spec's reserved names either.

## Fix

- Added a new dependency-free module, `packages/ssr/src/lib/shared/customElementName.ts`, containing:
  - `mayBeCustomElementTagName` — the cheap `includes("-")` fast-path check.
  - `isValidCustomElementTagName` — full PotentialCustomElementName grammar validation *plus* rejection of the spec's reserved SVG/MathML names.
- `runtime/html.ts` now re-exports `isValidCustomElementTagName` from the shared module instead of defining its own copy.
- `vite/vitePluginSvebcomponentsSsr.ts` now imports both predicates from the shared module and only wraps an element when it passes the cheap fast path *and* the full validation, instead of the bare `includes("-")` check.
- The shared module has zero imports (no `svelte/internal/server`), so the Vite plugin's dependency graph stays free of Svelte SSR runtime code — verified by inspecting the built `dist/vite/vitePluginSvebcomponentsSsr.js`, which only imports the pure shared module.

## Tests

- `packages/ssr/src/lib/shared/customElementName.test.ts` (new): unit tests for both predicates, including rejection of all 8 spec-reserved names.
- `packages/ssr/src/lib/runtime/html.test.ts` (new): unit tests for the re-exported `isValidCustomElementTagName`, including reserved-name rejections.
- `packages/ssr/src/lib/vite/vitePluginSvebcomponentsSsr.test.ts` (new): verifies `<font-face>` (and other reserved names) nested in `<svg>` are *not* wrapped, while a real custom element (`<my-element>`) still is, including when they're siblings.

## Verification

- `pnpm -F @svebcomponents/ssr build && pnpm -F @svebcomponents/ssr test` — pass (110 tests).
- `pnpm -F @svebcomponents/ssr lint && pnpm -F @svebcomponents/ssr check` — pass, 0 errors/warnings.
- Full `pnpm build && pnpm test` from repo root — pass (17/17 tasks).
- Added changeset: `.changeset/fix-reserved-svg-names.md` (`@svebcomponents/ssr` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)