### PR TITLE
fix(ssr): use server attr implementation in slot override module

### DIFF
--- a/.changeset/fix-slot-module-server-attr.md
+++ b/.changeset/fix-slot-module-server-attr.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Use `attr` from `svelte/internal/server` instead of `svelte/internal/client` in the SSR slot override virtual module, so server bundles no longer directly depend on Svelte's client-internal entry point. Rendered output is unchanged: both entries re-export the same shared `attr` implementation.

--- a/packages/ssr/src/lib/rollup/pluginOverrideSvelteSsrSlotImplementation.ts
+++ b/packages/ssr/src/lib/rollup/pluginOverrideSvelteSsrSlotImplementation.ts
@@ -29,8 +29,8 @@ export function pluginOverrideSvelteSsrSlotImplementation(): Plugin {
 // --- virtual module: ${VIRTUAL_MODULE_ID} ---
 // import & reexport everything from the original module.
 export * from 'svelte/internal/server';
-// use 'attr' from svelte internal, because we depend on internal anyways & it has escaping built-in
-import { attr } from 'svelte/internal/client';
+// use 'attr' from svelte internal server, because we depend on internal anyways & it has escaping built-in
+import { attr } from 'svelte/internal/server';
 
 /**
  * override the original slot function for usage with '@svebcomponents/ssr'.


### PR DESCRIPTION
## Problem (audit S6)

The virtual module in `packages/ssr/src/lib/rollup/pluginOverrideSvelteSsrSlotImplementation.ts` that overrides Svelte's SSR `slot()` implementation imported `attr` from **`svelte/internal/client`** — inside a SERVER bundle. Meanwhile the runtime (`packages/ssr/src/lib/runtime/html.ts`) uses **`svelte/internal/server`**'s `attr` for the same job. Two different internal APIs for one purpose: the client-internal import adds a direct dependency on Svelte's client entry point in SSR bundles and doubles the exposure to Svelte-internal churn.

## Fix

The virtual module now imports `attr` from `svelte/internal/server`, matching the runtime. The import goes through the plugin's existing `resolveId` base case (imports of `svelte/internal/server` *from the virtual module itself* resolve to the real module), same as the existing `export * from 'svelte/internal/server'`.

## Signature-compatibility verification

In the pinned Svelte version (5.28.2), both entry points re-export the **identical function object** from `internal/shared/attributes.js`:

- `svelte/src/internal/server/index.js:495` → `export { attr, clsx };` (imported from `../shared/attributes.js`)
- `svelte/src/internal/client/index.js:153` → `export { attr, clsx } from '../shared/attributes.js';`

Runtime check:

```
same function object:                 true
server attr('name', null):            ""        <- default slot: renders nothing
server attr('name', 'foo'):           " name=\"foo\""
server attr('disabled', true, true):  " disabled"
server attr('disabled', false, true): ""
server attr('x', '<"&'):              " x=\"&lt;&quot;&amp;\""  <- escaping intact
```

Signature is `attr(name, value, is_boolean = false)` and returns `''` when `value == null`, so the default-slot case (`attr('name', null)`) still emits no `name` attribute.

## Before/after evidence

Bundled a slot-exercising entry through the plugin with rolldown in both states and executed it:

```
BEFORE: "<slot>fallback-content</slot>|<slot name=\"header\" level=\"2\" sticky title=\"&lt;&quot;&amp;\"></slot>"
AFTER:  "<slot>fallback-content</slot>|<slot name=\"header\" level=\"2\" sticky title=\"&lt;&quot;&amp;\"></slot>"
```

- Rendered output: identical (default slot, named slot, boolean prop, escaped value).
- Bundle: byte-identical except the random temp entry path; module graph identical (90 modules).
- e2e ssr suite (`@svebcomponents/e2e.ssr`): 6/6 tests pass both before and after, including the strict-equal full-render assertion.

Note: in Svelte 5.28.2 `svelte/internal/server` itself transitively imports some client-internal sources, so those modules appear in the bundle either way — this fix removes *our* direct dependency on the client entry, which is the churn-exposure the audit flagged.

## Verification

- `pnpm -F @svebcomponents/ssr build && pnpm -F @svebcomponents/ssr test` — 54/54 pass
- `pnpm build && pnpm test` from root — 17/17 tasks pass
- Changeset added: `@svebcomponents/ssr` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)