### PR TITLE
fix(auto-options): handle union and function prop types, route warnings to console.warn

### DIFF
--- a/.changeset/fix-auto-options-warnings.md
+++ b/.changeset/fix-auto-options-warnings.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/auto-options": patch
+---
+
+Route build warnings through `console.warn` with a consistent `[svebcomponents/auto-options]` prefix, resolve union prop types (e.g. `string | null`, `number | undefined`, literal unions) without spurious "unhandled type" warnings, and omit function- and `Snippet`-typed props from the generated custom element props so they stay property-only instead of receiving meaningless attribute/reflect metadata.

--- a/packages/auto-options/src/extractSvelteOptionsProps.ts
+++ b/packages/auto-options/src/extractSvelteOptionsProps.ts
@@ -40,8 +40,8 @@ export const extractSvelteOptions = (
     expression.type !== "ObjectExpression" ||
     !("end" in expression && typeof expression["end"] === "number")
   ) {
-    console.log(
-      'Svelte Options with the format `<svelte:options customElement="tagName"/>` are currently not supported. Please switch to the object variant of defining custom element options.',
+    console.warn(
+      '[svebcomponents/auto-options] Svelte Options with the format `<svelte:options customElement="tagName"/>` are currently not supported. Please switch to the object variant of defining custom element options.',
     );
     return {
       attributeInjectIndex,

--- a/packages/auto-options/src/fixtures/function_prop/input.svelte
+++ b/packages/auto-options/src/fixtures/function_prop/input.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+  interface Props {
+    label: string;
+    onClick?: () => void;
+  }
+  let { label, onClick }: Props = $props();
+</script>
+<button onclick={onClick}>{label}</button>

--- a/packages/auto-options/src/fixtures/function_prop/output.svelte
+++ b/packages/auto-options/src/fixtures/function_prop/output.svelte
@@ -1,0 +1,13 @@
+<svelte:options customElement={{
+props: {
+label: {attribute: "label", reflect: true, type: "String"},
+}
+}} />
+<script lang="ts">
+  interface Props {
+    label: string;
+    onClick?: () => void;
+  }
+  let { label, onClick }: Props = $props();
+</script>
+<button onclick={onClick}>{label}</button>

--- a/packages/auto-options/src/fixtures/snippet/input.svelte
+++ b/packages/auto-options/src/fixtures/snippet/input.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  interface Props {
+    title: string;
+    children?: Snippet;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props.title}</h1>
+{@render props.children?.()}

--- a/packages/auto-options/src/fixtures/snippet/output.svelte
+++ b/packages/auto-options/src/fixtures/snippet/output.svelte
@@ -1,0 +1,15 @@
+<svelte:options customElement={{
+props: {
+title: {attribute: "title", reflect: true, type: "String"},
+}
+}} />
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  interface Props {
+    title: string;
+    children?: Snippet;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props.title}</h1>
+{@render props.children?.()}

--- a/packages/auto-options/src/fixtures/union_mixed/input.svelte
+++ b/packages/auto-options/src/fixtures/union_mixed/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  interface Props {
+    mixedProp: string | number;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>

--- a/packages/auto-options/src/fixtures/union_mixed/output.svelte
+++ b/packages/auto-options/src/fixtures/union_mixed/output.svelte
@@ -1,0 +1,12 @@
+<svelte:options customElement={{
+props: {
+mixedProp: {attribute: "mixed-prop", reflect: true, type: "String"},
+}
+}} />
+<script lang="ts">
+  interface Props {
+    mixedProp: string | number;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>

--- a/packages/auto-options/src/fixtures/union_null/input.svelte
+++ b/packages/auto-options/src/fixtures/union_null/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  interface Props {
+    stringProp: string | null;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>

--- a/packages/auto-options/src/fixtures/union_null/output.svelte
+++ b/packages/auto-options/src/fixtures/union_null/output.svelte
@@ -1,0 +1,12 @@
+<svelte:options customElement={{
+props: {
+stringProp: {attribute: "string-prop", reflect: true, type: "String"},
+}
+}} />
+<script lang="ts">
+  interface Props {
+    stringProp: string | null;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>

--- a/packages/auto-options/src/fixtures/union_string_literals/input.svelte
+++ b/packages/auto-options/src/fixtures/union_string_literals/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  interface Props {
+    variant: "primary" | "secondary";
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>

--- a/packages/auto-options/src/fixtures/union_string_literals/output.svelte
+++ b/packages/auto-options/src/fixtures/union_string_literals/output.svelte
@@ -1,0 +1,12 @@
+<svelte:options customElement={{
+props: {
+variant: {attribute: "variant", reflect: true, type: "String"},
+}
+}} />
+<script lang="ts">
+  interface Props {
+    variant: "primary" | "secondary";
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>

--- a/packages/auto-options/src/fixtures/union_undefined/input.svelte
+++ b/packages/auto-options/src/fixtures/union_undefined/input.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  interface Props {
+    numberProp: number | undefined;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>

--- a/packages/auto-options/src/fixtures/union_undefined/output.svelte
+++ b/packages/auto-options/src/fixtures/union_undefined/output.svelte
@@ -1,0 +1,12 @@
+<svelte:options customElement={{
+props: {
+numberProp: {attribute: "number-prop", reflect: true, type: "Number"},
+}
+}} />
+<script lang="ts">
+  interface Props {
+    numberProp: number | undefined;
+  }
+  let props: Props = $props();
+</script>
+<h1>{props}</h1>

--- a/packages/auto-options/src/inferProps.ts
+++ b/packages/auto-options/src/inferProps.ts
@@ -9,6 +9,13 @@ import type {
 import { kebabize } from "@svebcomponents/utils";
 import type { SvelteOptions } from "./extractSvelteOptionsProps";
 
+const WARNING_PREFIX = "[svebcomponents/auto-options]";
+
+// marker for prop types that cannot be (de)serialized to an attribute value (functions, snippets)
+const NON_SERIALIZABLE = "NonSerializable";
+
+type ResolvedPropType = PrimitiveType | typeof NON_SERIALIZABLE;
+
 const primitiveTypes = {
   String: "String",
   Array: "Array",
@@ -32,6 +39,8 @@ const enhanceInferredProps = (
 ) => {
   // first we check if the propName is already in the inferred props
   const previouslyInferredProp = inferredProps[propName];
+  // props already known to be non-serializable (functions, snippets) never get attribute metadata
+  if (previouslyInferredProp?.isNonSerializable) return;
   // and then update the previously inferred props, trying to not overwrite previous (more valuable) information
   inferredProps[propName] = {
     attributeName: previouslyInferredProp?.attributeName ?? attributeName,
@@ -75,7 +84,7 @@ export const inferPropsFromSvelteOptions = (
 const resolvePrimitiveType = (
   type: Type,
   typeDeclarations: TypeDeclaration[],
-): PrimitiveType | null => {
+): ResolvedPropType | null => {
   // there are way to many ways to write simple types in TS.. T.T
   switch (type.type) {
     case "TSStringKeyword":
@@ -112,7 +121,13 @@ const resolvePrimitiveType = (
           return typeDeclaration.id.name === type.typeName.name;
         },
       );
-      if (!resolvedTypeDeclaration) return null;
+      if (!resolvedTypeDeclaration) {
+        // `Snippet` props (imported from "svelte") are render functions & cannot be expressed as attributes
+        if (type.typeName.name === "Snippet") {
+          return NON_SERIALIZABLE;
+        }
+        return null;
+      }
       if (resolvedTypeDeclaration?.type === "TSInterfaceDeclaration") {
         return "Object";
       }
@@ -121,10 +136,44 @@ const resolvePrimitiveType = (
         typeDeclarations,
       );
     }
+    case "TSUnionType": {
+      const resolvedMemberTypes = new Set<ResolvedPropType>();
+      for (const member of type.types) {
+        // `null` / `undefined` union members carry no type information for attribute handling,
+        // idiomatic unions like `string | null` should simply resolve to their meaningful member
+        if (
+          member.type === "TSNullKeyword" ||
+          member.type === "TSUndefinedKeyword"
+        ) {
+          continue;
+        }
+        const resolvedMemberType = resolvePrimitiveType(
+          member,
+          typeDeclarations,
+        );
+        if (resolvedMemberType === null) continue;
+        resolvedMemberTypes.add(resolvedMemberType);
+      }
+      const [firstResolvedMemberType] = resolvedMemberTypes;
+      // a union without resolvable meaningful members (e.g. `null | undefined`) tells us nothing
+      if (firstResolvedMemberType === undefined) return null;
+      // if all meaningful members resolve to the same type (e.g. `string | null` or `"a" | "b"`), use it
+      if (resolvedMemberTypes.size === 1) return firstResolvedMemberType;
+      console.warn(
+        `${WARNING_PREFIX} cannot infer a single attribute type for a union mixing [${[...resolvedMemberTypes].join(", ")}], falling back to "String". Specify the type explicitly via <svelte:options customElement={{ props }} /> to override.`,
+      );
+      return "String";
+    }
+    case "TSFunctionType":
+      return NON_SERIALIZABLE;
+    case "TSNullKeyword":
+    case "TSUndefinedKeyword":
+      // these carry no type information for attribute handling
+      return null;
     default:
       // at some point the switch statement should be exhaustive & this log never trigger
-      console.log(
-        "@svebcomponents/auto-options found unhandled type while trying to resolve primitive type: ",
+      console.warn(
+        `${WARNING_PREFIX} found unhandled type while trying to resolve primitive type:`,
         type,
       );
       return null;
@@ -158,8 +207,8 @@ export const inferPropsFromTypes = (
     switch (resolvedTypeDeclaration?.type) {
       case "TSTypeAliasDeclaration":
         if (resolvedTypeDeclaration?.typeAnnotation.type !== "TSTypeLiteral") {
-          console.log(
-            "@svebcomponents/auto-options could not resolve prop types since they were not of expected shape",
+          console.warn(
+            `${WARNING_PREFIX} could not resolve prop types since they were not of expected shape`,
           );
           return;
         }
@@ -183,16 +232,24 @@ export const inferPropsFromTypes = (
   }
 
   for (const { typeAnnotation, key } of typedProps) {
-    const resolvedPrimitiveType = resolvePrimitiveType(
+    const resolvedPropType = resolvePrimitiveType(
       typeAnnotation.typeAnnotation,
       typeDeclarations,
     );
     const propName = key.name;
+    if (resolvedPropType === NON_SERIALIZABLE) {
+      // function / snippet props cannot be reflected to or parsed from attributes;
+      // by omitting them from the generated custom element props, svelte exposes them
+      // as plain JS properties without any attribute handling.
+      // we still respect explicit user configuration from <svelte:options> if present.
+      inferredProps[propName] ??= { isNonSerializable: true };
+      continue;
+    }
     enhanceInferredProps(
       inferredProps,
       propName,
       kebabize(propName),
-      resolvedPrimitiveType ?? "String",
+      resolvedPropType ?? "String",
     );
   }
 };

--- a/packages/auto-options/src/injectInferredProps.ts
+++ b/packages/auto-options/src/injectInferredProps.ts
@@ -7,9 +7,14 @@ export const injectInferredProps = (
   svelteOptions: SvelteOptions | null,
   magicString: MagicString,
 ) => {
-  if (Object.keys(inferredProps).length === 0) return;
+  // non-serializable props (functions, snippets) are omitted from the generated props,
+  // svelte then exposes them as plain JS properties without any attribute handling
+  const serializableProps = Object.entries(inferredProps).filter(
+    ([, inferredProp]) => !inferredProp.isNonSerializable,
+  );
+  if (serializableProps.length === 0) return;
   let inferredPropsResult = "props: {\n";
-  for (const [propName, inferredProp] of Object.entries(inferredProps)) {
+  for (const [propName, inferredProp] of serializableProps) {
     inferredPropsResult += `${propName}: {attribute: "${inferredProp.attributeName}", reflect: ${inferredProp.isReflected}, type: "${inferredProp.type}"},\n`;
   }
   inferredPropsResult += "}";

--- a/packages/auto-options/src/types.ts
+++ b/packages/auto-options/src/types.ts
@@ -12,6 +12,9 @@ export interface SvelteOptionProp {
   attributeName?: string | undefined;
   isReflected?: boolean | undefined;
   type?: PrimitiveType | undefined;
+  // props with non-serializable types (functions, snippets) must not get attribute metadata,
+  // they are exposed as JS properties on the custom element only
+  isNonSerializable?: boolean | undefined;
 }
 
 export interface InferredSvelteOptionProps {
@@ -72,6 +75,23 @@ interface TSTypeLiteral extends AST.BaseNode {
   members: PropertySignature[];
 }
 
+interface TSUnionType extends AST.BaseNode {
+  type: "TSUnionType";
+  types: Type[];
+}
+
+interface TSFunctionType extends AST.BaseNode {
+  type: "TSFunctionType";
+}
+
+interface TSNullKeyword extends AST.BaseNode {
+  type: "TSNullKeyword";
+}
+
+interface TSUndefinedKeyword extends AST.BaseNode {
+  type: "TSUndefinedKeyword";
+}
+
 interface TypeAnnotation extends AST.BaseNode {
   typeAnnotation: Type;
 }
@@ -106,6 +126,10 @@ export type Type =
   | TSNumberKeyword
   | TSTypeLiteral
   | TSLiteralType
-  | TSBooleanKeyword;
+  | TSBooleanKeyword
+  | TSUnionType
+  | TSFunctionType
+  | TSNullKeyword
+  | TSUndefinedKeyword;
 
 export type TypeDeclaration = InterfaceDeclaration | TypeAliasDeclaration;


### PR DESCRIPTION
## Problem

Audited issue S2 in `@svebcomponents/auto-options`:

- Build warnings went through `console.log` (stdout) instead of `console.warn` (stderr), in `resolvePrimitiveType`'s default case (`inferProps.ts`) and in `extractSvelteOptionsProps.ts`.
- The scary "unhandled type" log fired for **every** union type — including idiomatic `string | null` / `number | undefined` unions — and then silently fell back to `type: "String"`.
- Function- and `Snippet`-typed props got a kebab-cased attribute and `reflect: true` like any other prop, which is meaningless for non-serializable values.

## Changes

- All warnings now go through `console.warn` with a consistent `[svebcomponents/auto-options]` prefix.
- `resolvePrimitiveType` handles `TSUnionType`:
  - `TSNullKeyword` / `TSUndefinedKeyword` members are ignored, so `string | null` resolves to `String` and `number | undefined` to `Number` — no warning.
  - If all meaningful members resolve to the same primitive (e.g. `"primary" | "secondary"`), that primitive is used — no warning.
  - Unions mixing multiple primitives (e.g. `string | number`) fall back to `String` with a quieter, precise one-line warning suggesting an explicit `<svelte:options>` override, instead of the unhandled-type AST dump.
- Function-shaped props (`TSFunctionType`, and unresolved `Snippet` type references) are treated as non-serializable and **omitted from the generated `customElement.props` entirely** (no attribute, no reflect). Explicit user configuration for such a prop via `<svelte:options>` still wins.
- The hand-rolled TS AST types in `types.ts` gained `TSUnionType`, `TSFunctionType`, `TSNullKeyword`, and `TSUndefinedKeyword`, following the existing pattern.

## Design decision: why omit function props from `props`?

Svelte's compiler adds every component prop that is missing from `customElement.props` with an **empty definition** (`props_str.push(b.init(key, b.object([])))` in `transform-client.js`). Verified on the compiled output of the new `function_prop` fixture:

```js
create_custom_element(Test, {
  label: { attribute: 'label', reflect: true, type: 'String' },
  onClick: {}
}, ...)
```

With an empty definition, the runtime (`create_custom_element`) still defines the property getter/setter on the element prototype — so `el.onClick = fn` keeps reaching the component instance — but performs no attribute→prop type coercion and no reflection (`reflect` is falsy). That is the minimal correct behavior for non-serializable props: property-only, no meaningless kebab-cased attribute handling.

The omission is tracked via an `isNonSerializable` marker on the inferred prop entry, so the later destructuring-based inference pass can't resurrect attribute metadata for it, and `injectInferredProps` skips such entries (and injects nothing at all if no serializable props remain).

## Fixtures added

- `union_null` — `string | null` → `String`, no warning
- `union_undefined` — `number | undefined` → `Number`, no warning
- `union_string_literals` — `"primary" | "secondary"` → `String`, no warning
- `union_mixed` — `string | number` → `String` fallback (quiet precise warning)
- `function_prop` — `onClick?: () => void` gets no attribute metadata (destructured props form, exercising all inference passes)
- `snippet` — `children?: Snippet` gets no attribute metadata

## Verification

- `pnpm -F @svebcomponents/auto-options build` and `test`: 27/27 tests pass
- Full `pnpm build && pnpm test` from root: all 10 build tasks and 17 test tasks pass
- e2e/auto-options build emits no unhandled-type warnings (grepped full uncached build log)
- `pnpm -F @svebcomponents/auto-options lint` clean
- Compiled a transformed function-prop component with `svelte/compiler` (`customElement: true`) to confirm the omitted prop yields `onClick: {}` (property-only, not reflected)

Note for maintainers: kept the `enhanceInferredProps` diff to a minimal early-return so the rebase against #73 stays small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d