### PR TITLE
fix(build,auto-options): Windows-portable path handling and dist cleanup

### DIFF
--- a/.changeset/fix-windows-portability.md
+++ b/.changeset/fix-windows-portability.md
@@ -1,0 +1,16 @@
+---
+"@svebcomponents/build": patch
+"@svebcomponents/auto-options": patch
+---
+
+Fix Windows portability issues:
+
+- `@svebcomponents/build` now uses `path.posix` consistently in
+  `inferComponents`. The values flowing through it come from package.json
+  `exports` (always posix) and become generated import specifiers, which must
+  stay posix. Previously `path.normalize` could flip them to backslashes on
+  win32. `existsSync` filesystem checks remain safe because Node's fs APIs
+  accept forward slashes on Windows.
+- `@svebcomponents/auto-options` build script no longer relies on `rm -rf`,
+  which fails on Windows cmd/PowerShell. It now uses a portable `node -e`
+  `fs.rmSync` call to clean stale `dist` output before `tsc`.

--- a/packages/auto-options/package.json
+++ b/packages/auto-options/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/auto-options"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && publint",
+    "build": "node -e \"fs.rmSync('dist',{recursive:true,force:true})\" && tsc && publint",
     "check": "tsc --noEmit",
     "lint": "pnpm /^lint:.*/",
     "lint:eslint": "eslint .",

--- a/packages/build/src/inferComponents.test.ts
+++ b/packages/build/src/inferComponents.test.ts
@@ -236,4 +236,19 @@ describe("infer components", () => {
     const inferredComponents = inferComponents({ exports: {} });
     expect(inferredComponents).toStrictEqual([]);
   });
+  it("emits posix (forward slash) paths for outDir and entry", () => {
+    // `exports` paths are always posix and the inferred values flow into
+    // generated import specifiers, so they must never contain backslashes,
+    // even when this code runs on Windows (guards against a regression where
+    // `path.normalize` re-introduces platform-native separators).
+    mockFs.existsSync.mockReturnValue(true);
+    const inferredComponents = inferComponents(svelteConditionPackageJson);
+    // stringify the whole config graph so every path-bearing field is checked
+    const serialized = JSON.stringify(inferredComponents);
+    expect(serialized).not.toContain("\\");
+    expect(serialized).toContain("dist/client");
+    expect(serialized).toContain("dist/server");
+    expect(serialized).toContain("dist/client-svelte");
+    expect(serialized).toContain("dist/server-svelte");
+  });
 });

--- a/packages/build/src/inferComponents.ts
+++ b/packages/build/src/inferComponents.ts
@@ -14,11 +14,15 @@ const resolveSvebcomponentEntryPoint = (
   entryPath: string,
   type: "client" | "server",
 ) => {
+  // `entryPath` originates from package.json `exports`, which are always posix
+  // ("./dist/client/index.js"). We therefore treat every path here as posix.
+  // The `existsSync` filesystem checks are safe with posix separators because
+  // Node's fs APIs accept forward slashes on Windows as well.
   const entry = entryPath.replace(`dist/${type}`, "src");
   if (existsSync(entry)) {
     return entry;
   }
-  const tsEntry = entry.replace(path.extname(entry), ".ts");
+  const tsEntry = entry.replace(path.posix.extname(entry), ".ts");
   if (!existsSync(tsEntry)) {
     throw new Error(
       `[svebcomponents]: could not find entry file for component at ${entry} or ${tsEntry}. Please ensure that the entry file exists.`,
@@ -48,8 +52,11 @@ export const inferComponents = (packageJson: unknown): Options[] => {
     if (typeof esmPath !== "string" || !esmPath.includes("dist/client")) {
       return undefined;
     }
-    const outDir = path.normalize(path.dirname(esmPath));
-    const entry = path.normalize(
+    // All values below are derived from posix `exports` paths and flow into
+    // generated import specifiers, so we must keep them posix (forward slashes)
+    // on every platform, including Windows.
+    const outDir = path.posix.normalize(path.posix.dirname(esmPath));
+    const entry = path.posix.normalize(
       resolveSvebcomponentEntryPoint(esmPath, "client"),
     );
     const config: DefineConfigOptions = {
@@ -58,7 +65,9 @@ export const inferComponents = (packageJson: unknown): Options[] => {
     };
     const sveltePath = value["svelte"];
     if (typeof sveltePath === "string") {
-      config.svelteOutDir = path.normalize(path.dirname(sveltePath));
+      config.svelteOutDir = path.posix.normalize(
+        path.posix.dirname(sveltePath),
+      );
     }
     const ssrExportDeclaration = `${key}/ssr`;
     const ssr = ssrExportDeclaration in exports;
@@ -71,17 +80,22 @@ export const inferComponents = (packageJson: unknown): Options[] => {
           "[svebcomponents]: could not find expected ESM ssr export.",
         );
       }
-      const ssrOutDir = path.dirname(ssrPath);
-      config.ssrOutDir = path.normalize(ssrOutDir);
+      const ssrOutDir = path.posix.dirname(ssrPath);
+      config.ssrOutDir = path.posix.normalize(ssrOutDir);
       // The declared ssr export (e.g. "./dist/server/button-ssr.js") dictates the
       // basename of the generated renderer entry file ("button-ssr"). Threading it
       // through keeps the generated file matching the exported path and avoids
       // collisions when several SSR components share one ssrOutDir.
-      config.ssrEntryFileName = path.basename(ssrPath, path.extname(ssrPath));
+      config.ssrEntryFileName = path.posix.basename(
+        ssrPath,
+        path.posix.extname(ssrPath),
+      );
 
       const ssrSveltePath = ssrExport?.["svelte"];
       if (typeof ssrSveltePath === "string") {
-        config.ssrSvelteOutDir = path.normalize(path.dirname(ssrSveltePath));
+        config.ssrSvelteOutDir = path.posix.normalize(
+          path.posix.dirname(ssrSveltePath),
+        );
       }
     }
     return config;


### PR DESCRIPTION
## Problem (audit item S10)

Two Windows portability problems:

1. **`packages/build/src/inferComponents.ts` mixed `path.normalize` with posix usage.** The values flowing through `inferComponents` come from package.json `exports` — which are **always posix** (`./dist/client/index.js`) — and become generated import specifiers and out-dir values that must **stay posix**. `packages/build/src/index.ts` (`toImportPath`, `entryOutputFile`) already uses `path.posix.*` throughout, but `inferComponents.ts` used plain `path.normalize`/`path.dirname`/`path.extname`, which on win32 would flip separators to backslashes and corrupt the emitted import specifiers. The string checks `entryPath.replace("dist/client", "src")` and `esmPath.includes("dist/client")` also assume posix separators.

2. **`packages/auto-options/package.json` used `rm -rf dist`**, which fails on Windows cmd/PowerShell.

## Fix

1. `inferComponents.ts` now uses `path.posix` consistently for every `normalize`/`dirname`/`extname` call. The only place platform-native paths would matter is the `existsSync` filesystem checks in `resolveSvebcomponentEntryPoint`, and those are safe with posix separators because **Node's fs APIs accept forward slashes on Windows** — so posix-only is correct throughout. Reasoning is captured in a code comment.
2. `auto-options` build script replaces `rm -rf dist &&` with a portable, dependency-free `node -e "fs.rmSync('dist',{recursive:true,force:true})" && tsc`. The clean is kept intentionally (it prevents removed source files from leaving stale `dist` entries — `auto-options` is the only package that emits into a `dist` that needs this, the others don't clean); it's just made cross-platform. `fs` is available as a global in `node -e`, and `force:true` makes a missing `dist` a no-op.
3. Added a regression test asserting inferred `outDir`/`entry` values come out with forward slashes (no backslashes), guarding against a future `normalize` regression.
4. Changeset: `@svebcomponents/build` patch, `@svebcomponents/auto-options` patch.

### Scope

`packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts` uses `path.resolve` on `outputOptions.dir`, which is a **real filesystem path** and correctly stays platform-native — left unchanged. Only exports/import-specifier-related paths were touched.

### Rebase note

PR #79 (still open) also edits `packages/build/src/index.ts`, `inferComponents.ts`, and `inferComponents.test.ts` (ssrEntryFileName threading). This branch was written from `main` as-is; expect a small rebase/merge reconciliation in those files once one of the two lands. Changes here are line-local posix swaps, so the reconciliation should be mechanical.

## Verification

Verified on **macOS only** (no Windows CI available). The Windows correctness argument is by construction: all affected paths are posix `exports` strings kept posix, and `fs`/`existsSync` accept forward slashes on Windows.

- `pnpm -F @svebcomponents/build test` — 13 passed
- `pnpm -F @svebcomponents/auto-options build && pnpm -F @svebcomponents/auto-options test` — build clean, 21 passed
- `pnpm build && pnpm test` from root — 17/17 tasks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)