### PR TITLE
fix(build): remove duplicate Options import breaking tsc

### DIFF
--- a/.changeset/fix-duplicate-options-import.md
+++ b/.changeset/fix-duplicate-options-import.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/build": patch
+---
+
+Remove a duplicate `import type { Options } from "tsdown"` in `inferComponents.test.ts` that broke `tsc` for the package (introduced by a merge conflict resolution in #79).

--- a/packages/build/src/inferComponents.test.ts
+++ b/packages/build/src/inferComponents.test.ts
@@ -5,7 +5,6 @@ import { defineConfig } from "./index.js";
 import fs from "node:fs";
 import path from "node:path";
 import fsPromises from "fs/promises";
-import type { Options } from "tsdown";
 
 vi.mock("node:fs");
 const mockFs = fs as unknown as {


### PR DESCRIPTION
## Problem

`main` currently fails a full root build. PR #79's merge left `packages/build/src/inferComponents.test.ts` importing `type Options` from `tsdown` twice (lines 2 and 8) — a duplicate-identifier merge artifact from combining two branches that each independently added the same import. `tsc` rejects this outright:

```
src/inferComponents.test.ts(2,15): error TS2300: Duplicate identifier 'Options'.
src/inferComponents.test.ts(8,15): error TS2300: Duplicate identifier 'Options'.
```

This blocks `pnpm build` (and `pnpm turbo build`) for `@svebcomponents/build` on a clean checkout of `main`, which in turn was surfacing as a spurious-looking failure while rebasing unrelated PRs on top.

(Note: PR #100 was an earlier attempt at this same fix, opened by mistake from the wrong local branch — closed in favor of this one.)

## Fix

Remove the second, duplicate `import type { Options } from "tsdown"` line. No behavior change — this is a test-file-only compile fix.

## Verification

- `pnpm -F @svebcomponents/build test` — 14 tests pass.
- `pnpm turbo build --filter=@svebcomponents/build` — succeeds (previously failed with TS2300).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018E7KV999beY766bkcnUX4d