### PR TITLE
fix(ssr): svelte >=5.36 sync rendering, chunk-order-safe SSR entries, parallel-build clean race

### DIFF
--- a/.changeset/fix-parallel-build-clean-race.md
+++ b/.changeset/fix-parallel-build-clean-race.md
@@ -1,0 +1,6 @@
+---
+"@svebcomponents/build": patch
+"@svebcomponents/ssr": patch
+---
+
+Fix a race that could corrupt build output when several components share an output directory (e.g. multiple components inferred from package.json `exports` writing to `dist/client`): component configs are built in parallel and tsdown's default per-build `clean` deleted sibling builds' output. The config factories now set `clean: false` and the `svebcomponents` CLI cleans each distinct output directory once before building.

--- a/.changeset/fix-sync-render-and-shim-ordering.md
+++ b/.changeset/fix-sync-render-and-shim-ordering.md
@@ -1,0 +1,8 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+Fix SSR breakage with svelte >= 5.36 and a chunk-ordering crash in production SvelteKit builds:
+
+- `SvelteCustomElementRenderer.renderShadow` now recognizes svelte's lazily-evaluated `RenderOutput` (always thenable since svelte 5.36) and renders synchronous components through its sync `head`/`body` getters. This un-breaks the sync wrapper (`collectResultSync` previously threw `Promises not supported in collectResultSync` for every component); only genuinely asynchronous components now require the async wrapper.
+- The generated SSR entry (`dist/server/ssr.js`) now installs the DOM shim via the new `@svebcomponents/ssr/shim` subpath export **before** loading the client custom-element bundle, and loads that bundle with a dynamic import. Previously, bundlers that code-split (e.g. rollup in a SvelteKit `adapter-node` build) could hoist the client bundle into a shared chunk that evaluated before the shim installed, crashing at startup with `Class extends value undefined is not a constructor or null` (svelte's `SvelteElement` captures `HTMLElement` at module-evaluation time). Dev mode was unaffected, which made the crash easy to miss.

--- a/e2e/ssr/package.json
+++ b/e2e/ssr/package.json
@@ -17,6 +17,14 @@
       "types": "./dist/server/ssr.d.ts",
       "svelte": "./dist/server-svelte/ssr.js",
       "default": "./dist/server/ssr.js"
+    },
+    "./sync": {
+      "types": "./dist/client/sync.d.ts",
+      "default": "./dist/client/sync.js"
+    },
+    "./sync/ssr": {
+      "types": "./dist/server/sync-ssr.d.ts",
+      "default": "./dist/server/sync-ssr.js"
     }
   },
   "devDependencies": {

--- a/e2e/ssr/src/SyncComponent.svelte
+++ b/e2e/ssr/src/SyncComponent.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  interface Props {
+    title: string;
+    count?: number;
+    enabled?: boolean;
+  }
+
+  let { title, count = 0, enabled = true }: Props = $props();
+</script>
+
+<div>
+  <h1>{title}</h1>
+  <p id="count">Count: {typeof count}-{count}</p>
+  <p id="enabled">Enabled: {typeof enabled}-{enabled}</p>
+</div>

--- a/e2e/ssr/src/sync.ts
+++ b/e2e/ssr/src/sync.ts
@@ -1,0 +1,7 @@
+import SyncComponent from "./SyncComponent.svelte";
+
+if (!customElements.get("sync-component") && SyncComponent.element) {
+  customElements.define("sync-component", SyncComponent.element);
+}
+
+export default SyncComponent;

--- a/e2e/ssr/test/sync/SyncSsrHost.svelte
+++ b/e2e/ssr/test/sync/SyncSsrHost.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  // import & register web component
+  import "../../dist/client/sync.js";
+
+  interface Props {
+    title: string;
+    count?: number;
+    enabled?: boolean;
+  }
+
+  let { title, count, enabled }: Props = $props();
+</script>
+
+<sync-component {title} {count} {enabled}></sync-component>

--- a/e2e/ssr/test/sync/renderSync.test.ts
+++ b/e2e/ssr/test/sync/renderSync.test.ts
@@ -1,0 +1,34 @@
+import { ElementRendererRegistry } from "@svebcomponents/ssr";
+import { render } from "svelte/server";
+import { test, expect } from "vitest";
+
+import SyncComponentRenderer from "../../dist/server/sync-ssr.js";
+
+import SyncSsrHost from "./SyncSsrHost.svelte";
+
+// This project intentionally runs WITHOUT `svebcomponents({ async: true })`
+// and WITHOUT svelte's `experimental.async`, i.e. the default configuration
+// every consumer gets: the sync wrapper + `collectResultSync`.
+test("renders a synchronous component through the sync wrapper", () => {
+  ElementRendererRegistry.set("sync-component", SyncComponentRenderer);
+
+  const res = render(SyncSsrHost, {
+    props: {
+      title: "Sync Test",
+      count: 3,
+      enabled: true,
+    },
+  });
+
+  // Deliberately NOT awaited: since svelte 5.36, render() results are always
+  // thenable, but the sync `body` getter must produce the full document for
+  // synchronous components (regression test: renderShadow previously pushed
+  // every result down the promise path, which collectResultSync rejects).
+  expect(res.body).toContain(
+    '<sync-component title="Sync Test" count="3" enabled="">',
+  );
+  expect(res.body).toContain('<template shadowrootmode="open">');
+  expect(res.body).toContain("<h1>Sync Test</h1>");
+  expect(res.body).toContain('<p id="count">Count: number-3</p>');
+  expect(res.body).toContain('<p id="enabled">Enabled: boolean-true</p>');
+});

--- a/e2e/ssr/vitest.config.ts
+++ b/e2e/ssr/vitest.config.ts
@@ -17,4 +17,20 @@ export default defineConfig({
       },
     }),
   ],
+  test: {
+    ...vitestConfig?.test,
+    projects: [
+      ...(vitestConfig?.test?.projects ?? []),
+      // The default consumer configuration: sync wrapper, no async option,
+      // no `experimental.async`. Deliberately does NOT extend the root
+      // config so the async plugins above don't leak in.
+      {
+        plugins: [svebcomponents(), svelte()],
+        test: {
+          name: "server-sync",
+          include: ["test/sync/*.test.ts"],
+        },
+      },
+    ],
+  },
 });

--- a/packages/build/src/cli.ts
+++ b/packages/build/src/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import fs from "node:fs/promises";
+
 import { build, type Options } from "tsdown";
 import { loadConfig as loadSvelteConfig } from "@sveltejs/load-config";
 import { loadConfig as loadSvebcomponentsConfig } from "unconfig";
@@ -44,6 +46,21 @@ async function main() {
   }
 
   const tsdownOptions = hasConfig ? config : defineConfig({ svelteConfig });
+
+  // Configs are built in parallel and several components may share an output
+  // directory (e.g. dist/client), so per-build cleaning (tsdown's `clean`)
+  // would race and delete sibling builds' output. Our config factories set
+  // `clean: false`; instead, clean each distinct output directory once here.
+  const outDirs = new Set(
+    tsdownOptions
+      .map((options) => options.outDir)
+      .filter((outDir): outDir is string => typeof outDir === "string"),
+  );
+  await Promise.all(
+    [...outDirs].map((outDir) =>
+      fs.rm(outDir, { recursive: true, force: true }),
+    ),
+  );
 
   await Promise.all(tsdownOptions.map(build));
 }

--- a/packages/build/src/svebcomponentConfig.ts
+++ b/packages/build/src/svebcomponentConfig.ts
@@ -28,6 +28,10 @@ export const createTsdownConfig = (options: SvebcomponentsOptions) => {
     entry,
     outDir,
     dts: true,
+    // Several component configs may share an output directory and are built
+    // in parallel by the svebcomponents CLI; tsdown's per-build clean would
+    // race and delete other builds' output. The CLI cleans once up front.
+    clean: false,
     ...(externalSvelte ? { external: [/^svelte(\/.*)?$/] } : {}),
     plugins: [
       autoOptions(),

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -32,6 +32,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./shim": {
+      "types": "./dist/runtime/installShim.d.ts",
+      "import": "./dist/runtime/installShim.js"
+    },
     "./wrapper-component": {
       "types": "./dist/vite/CustomElementWrapper.svelte.d.ts",
       "svelte": "./dist/vite/CustomElementWrapper.svelte"

--- a/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.test.ts
+++ b/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.test.ts
@@ -55,10 +55,16 @@ describe("pluginGenerateSsrEntry", () => {
       expect.stringContaining("dist/server/ssr.js"),
       expect.stringContaining("import ServerSvelteComponent from './index.js'"),
     );
+    // The shim must be imported before anything can evaluate the client bundle
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/ssr.js"),
+      expect.stringContaining("import '@svebcomponents/ssr/shim'"),
+    );
+    // The client bundle must be imported dynamically (chunk-order safety)
     expect(mockFs.writeFile).toHaveBeenCalledWith(
       expect.stringContaining("dist/server/ssr.js"),
       expect.stringContaining(
-        "import ClientSvelteComponent from '../client/index.js'",
+        "const ClientSvelteComponent = (await import('../client/index.js')).default",
       ),
     );
 
@@ -105,9 +111,7 @@ describe("pluginGenerateSsrEntry", () => {
     );
     expect(mockFs.writeFile).toHaveBeenCalledWith(
       expect.any(String),
-      expect.stringContaining(
-        "import ClientSvelteComponent from './custom-client.js'",
-      ),
+      expect.stringContaining("await import('./custom-client.js')"),
     );
   });
 

--- a/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts
+++ b/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts
@@ -53,9 +53,20 @@ export function pluginGenerateSsrEntry(
         `${entryFileName}.d.ts`,
       );
 
-      const content = `import { SvelteCustomElementRenderer } from '@svebcomponents/ssr';
+      const content = `// The DOM shim must be installed before the client custom-element bundle
+// evaluates: the compiled custom element (and svelte's client runtime it
+// bundles) captures \`HTMLElement\` at module-evaluation time.
+import '@svebcomponents/ssr/shim';
+import { SvelteCustomElementRenderer } from '@svebcomponents/ssr';
 import ServerSvelteComponent from '${serverImportPath}';
-import ClientSvelteComponent from '${clientImportPath}';
+
+// Import the client bundle dynamically instead of statically: bundlers that
+// code-split (e.g. rollup in a SvelteKit server build) may hoist a statically
+// imported module into a shared chunk that executes before this module's own
+// imports, evaluating the custom-element code before the shim above has
+// installed. Evaluation of a dynamic import can never be hoisted above the
+// importing module's body, so this is ordering-safe under any chunking.
+const ClientSvelteComponent = (await import('${clientImportPath}')).default;
 
 const ctor = ClientSvelteComponent.element;
 if (!ctor) {

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
@@ -345,6 +345,133 @@ describe("SvelteCustomElementRenderer", () => {
     expect(shadowContent).toEqual("");
   });
 
+  test("renderShadow renders svelte >=5.36 thenable RenderOutput synchronously via its lazy getters", () => {
+    // svelte >= 5.36 render() results are *always* thenable, but expose lazy
+    // sync `head`/`body` getters for synchronous components.
+    const renderOutput = {
+      get head() {
+        return "<style>/* lazy styles */</style>";
+      },
+      get body() {
+        return "<div>Lazy content</div>";
+      },
+      then: vi.fn(),
+    };
+    mockRender.mockReturnValue(
+      renderOutput as unknown as ReturnType<typeof render>,
+    );
+
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: {},
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    const renderResult = renderer.renderShadow({} as RenderInfo);
+    assert(renderResult);
+    // synchronous consumption must work (this is what collectResultSync does)
+    const chunks = Array.from(renderResult);
+    expect(chunks.every((chunk) => typeof chunk === "string")).toBe(true);
+    expect(chunks.join("")).toBe(
+      "<style>/* lazy styles */</style><div>Lazy content</div>",
+    );
+    // the promise path must not be taken for synchronous components
+    expect(renderOutput.then).not.toHaveBeenCalled();
+  });
+
+  test("renderShadow falls back to the promise path when sync access throws await_invalid", async () => {
+    // simulates a genuinely async component rendered with svelte >= 5.36:
+    // sync getters throw `await_invalid`, awaiting resolves.
+    const awaitInvalid = new Error(
+      "await_invalid\nEncountered asynchronous work while rendering synchronously.\nhttps://svelte.dev/e/await_invalid",
+    );
+    const renderOutput = {
+      get head(): string {
+        throw awaitInvalid;
+      },
+      get body(): string {
+        throw awaitInvalid;
+      },
+      then: (
+        onfulfilled: (value: { head: string; body: string }) => unknown,
+      ) => {
+        return Promise.resolve(
+          onfulfilled({
+            head: "<style>/* awaited styles */</style>",
+            body: "<div>Awaited content</div>",
+          }),
+        );
+      },
+    };
+    mockRender.mockReturnValue(
+      renderOutput as unknown as ReturnType<typeof render>,
+    );
+
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: {},
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    const renderResult = renderer.renderShadow({} as RenderInfo);
+    assert(renderResult);
+    const shadowContent = await collectResult(renderResult);
+
+    expect(shadowContent).toBe(
+      "<style>/* awaited styles */</style><div>Awaited content</div>",
+    );
+  });
+
+  test("renderShadow rethrows genuine render errors from sync getters", () => {
+    const renderError = new Error("something exploded inside the component");
+    const renderOutput = {
+      get head(): string {
+        throw renderError;
+      },
+      get body(): string {
+        throw renderError;
+      },
+      then: vi.fn(),
+    };
+    mockRender.mockReturnValue(
+      renderOutput as unknown as ReturnType<typeof render>,
+    );
+
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: {},
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+    );
+
+    const renderResult = renderer.renderShadow({} as RenderInfo);
+    assert(renderResult);
+    expect(() => Array.from(renderResult)).toThrow(renderError);
+  });
+
   test("renderShadow resolves async svelte render results", async () => {
     mockRender.mockReturnValue(
       Promise.resolve({

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
@@ -23,6 +23,35 @@ type SvelteRenderResult = {
   head: string;
 };
 
+/**
+ * Since svelte 5.36, `render()` returns a lazily-evaluated `RenderOutput`
+ * that is *always* thenable — even for fully synchronous components. Its
+ * `head`/`body` getters render synchronously and throw svelte's
+ * `await_invalid` error only when the component performs genuinely
+ * asynchronous work. Preferring the getters keeps synchronous components
+ * renderable through the sync wrapper (`collectResultSync`); only genuinely
+ * async components fall back to the promise path, which requires the async
+ * wrapper.
+ */
+const tryRenderSync = (
+  result: PromiseLike<SvelteRenderResult>,
+): SvelteRenderResult | undefined => {
+  try {
+    const { head, body } = result as unknown as SvelteRenderResult;
+    if (typeof head === "string" && typeof body === "string") {
+      return { head, body };
+    }
+    // a plain promise (no sync getters) — must be awaited
+    return undefined;
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("await_invalid")) {
+      return undefined;
+    }
+    // genuine render errors must not be swallowed
+    throw error;
+  }
+};
+
 export interface SvelteClientCustomElement {
   new (): Omit<SvelteClientCustomElement, "new">;
   attributes: Record<string, string>;
@@ -105,6 +134,12 @@ export class SvelteCustomElementRenderer
       props: this.svelteClientCustomElement.$$d,
     }) as unknown as SvelteRenderResult | PromiseLike<SvelteRenderResult>;
     if (isPromiseLike<SvelteRenderResult>(result)) {
+      const syncResult = tryRenderSync(result);
+      if (syncResult) {
+        yield syncResult.head;
+        yield syncResult.body;
+        return;
+      }
       yield Promise.resolve(result).then(({ body, head }) => [head, body]);
       return;
     }

--- a/packages/ssr/src/lib/tsdown/svebcomponentsSsrConfig.ts
+++ b/packages/ssr/src/lib/tsdown/svebcomponentsSsrConfig.ts
@@ -51,6 +51,10 @@ const createSsrTsdownConfig = ({
     entry,
     outDir,
     dts: true,
+    // Several component configs may share an output directory and are built
+    // in parallel by the svebcomponents CLI; tsdown's per-build clean would
+    // race and delete other builds' output. The CLI cleans once up front.
+    clean: false,
     ...(externalSvelte ? { external: [/^svelte(\/.*)?$/] } : {}),
     plugins: [
       pluginOverrideSvelteSsrSlotImplementation(),


### PR DESCRIPTION
Three production bugs found while dogfooding svebcomponents for the atproto-comments project, all fixed with regression coverage.

## 1. Sync SSR wrapper broken with svelte ≥ 5.36

Since svelte 5.36, `render()` returns a lazily-evaluated `RenderOutput` that is **always thenable** (to support `await render()`), with sync `head`/`body` getters that throw `await_invalid` only when a component performs genuinely asynchronous work. `renderShadow`'s `isPromiseLike` check therefore classified *every* component as async, and the sync wrapper died in `collectResultSync` (`Promises not supported in collectResultSync`) — the default configuration was 100% broken with current svelte.

**Fix:** `renderShadow` now prefers the sync getters and only falls back to the promise path when svelte signals `await_invalid`. Genuine render errors are rethrown; plain promises still work. Only genuinely async components require the async wrapper now.

## 2. `Class extends value undefined` crash in adapter-node production builds

Svelte's `SvelteElement` is captured at module-evaluation time (`typeof HTMLElement === 'function'` at module scope), so the DOM shim must be installed before any chunk containing compiled custom-element code evaluates. Rollup code-splitting can violate sibling-import ordering: in a SvelteKit `adapter-node` build where a page also imports the client bundle, the bundle landed in a shared chunk that evaluated **before** the entry-level shim side effect. Dev mode never chunks, which is why this went unnoticed.

**Fix:** new `@svebcomponents/ssr/shim` subpath export, and the generated `dist/server/ssr.js` imports it first, then loads the client bundle via **top-level-await dynamic import** — a dynamic import's evaluation can never be hoisted above the importing module's body, so the ordering holds under any chunking. Bonus: static client imports in pages become safe too, since page chunks always evaluate after server init.

## 3. Parallel-build clean race on shared output directories

Component configs are built with `Promise.all`, and tsdown's default `clean: true` rimrafs the outDir per build — with several components sharing `dist/client` (the documented multi-component `exports` inference), builds could delete each other's output. Surfaced while adding the e2e coverage below.

**Fix:** config factories set `clean: false`; the CLI cleans each distinct outDir once before building.

## Test coverage

- 3 new renderer unit tests (sync getters preferred + `then` not called, `await_invalid` fallback, genuine errors rethrown)
- `pluginGenerateSsrEntry` tests updated for the new entry shape
- **New `server-sync` e2e project**: the sync wrapper (default consumer config, previously zero coverage — how bug 1 shipped) now renders a second, synchronous component without `async: true` / `experimental.async`, asserting `res.body` synchronously. Verified to fail against the pre-fix renderer. Also exercises multi-component inference from package.json `exports`.

Changesets included (patch: `@svebcomponents/ssr`, `@svebcomponents/build`).

Verified end-to-end in a SvelteKit consumer app: sync default config + static client import now work in both `vite dev` and `adapter-node` production builds (declarative shadow DOM served correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Rp63YFbEhnQjhqs4jWGg