### PR TITLE
fix: split npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ on:
       - "configs/*/CHANGELOG.md"
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -40,8 +40,4 @@ jobs:
         run: pnpm install
 
       - name: Publish to npm
-        uses: changesets/action@v1
-        with:
-          publish: pnpm release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm release


### PR DESCRIPTION
## What changed

- Run pnpm release directly in the dedicated publish workflow.
- Reduce repository contents permission from write to read.
- Remove the unnecessary GITHUB_TOKEN from the publish step.

## Why

After the release flow was split, the publish workflow continued to invoke changesets/action. When pending changesets were present, that action took its release-PR path and attempted to create a pull request without pull-requests: write, causing the publish job to fail with Resource not accessible by integration.

The release workflow remains responsible for creating version pull requests. The publish workflow now has one responsibility: publishing versions prepared by the merged release PR through npm trusted publishing.

## Validation

- git diff --check
- Parsed .github/workflows/publish.yml with Ruby YAML