### PR TITLE
feat: support inferred SSR prepare hooks

### DIFF
--- a/.changeset/fuzzy-pandas-prepare.md
+++ b/.changeset/fuzzy-pandas-prepare.md
@@ -1,0 +1,8 @@
+---
+"@svebcomponents/build": minor
+"@svebcomponents/ssr": minor
+---
+
+Add automatically discovered, server-only `entry.ssr.ts` preparation hooks for
+setting component properties before SSR and serializing the results for
+hydration.

--- a/e2e/ssr/src/Component.svelte
+++ b/e2e/ssr/src/Component.svelte
@@ -3,9 +3,10 @@
     title: string;
     count?: number;
     enabled?: boolean;
+    prepared?: { source: string };
   }
 
-  let { title, count = 0, enabled = true }: Props = $props();
+  let { title, count = 0, enabled = true, prepared }: Props = $props();
 
   const asyncLabel = await Promise.resolve("Async: resolved");
 </script>
@@ -15,4 +16,5 @@
   <p id="count">Count: {typeof count}-{count}</p>
   <p id="enabled">Enabled: {typeof enabled}-{enabled}</p>
   <p id="async-label">{asyncLabel}</p>
+  <p id="prepared">Prepared: {prepared?.source ?? "none"}</p>
 </div>

--- a/e2e/ssr/src/index.ssr.ts
+++ b/e2e/ssr/src/index.ssr.ts
@@ -1,0 +1,13 @@
+import type { SsrPrepare } from "@svebcomponents/ssr";
+
+const prepare: SsrPrepare = ({ props, setProperty }) => {
+  // Returning synchronously preserves the sync fast path when callers already
+  // supplied the prepared value.
+  if (props.prepared !== undefined) return;
+
+  return Promise.resolve().then(() => {
+    setProperty("prepared", { source: "adjacent server module" });
+  });
+};
+
+export default prepare;

--- a/e2e/ssr/test/server/render.test.ts
+++ b/e2e/ssr/test/server/render.test.ts
@@ -26,6 +26,10 @@ test("rendering svelte with async SSR renderer", async () => {
   expect(res.body).toContain('<p id="count">Count: number-5</p>');
   expect(res.body).toContain('<p id="enabled">Enabled: boolean-true</p>');
   expect(res.body).toContain('<p id="async-label">Async: resolved</p>');
+  expect(res.body).toContain(
+    '<p id="prepared">Prepared: adjacent server module</p>',
+  );
+  expect(res.body).toContain('"prepared":{"source":"adjacent server module"}');
 });
 
 test("escapes untrusted values rendered through shadow props", async () => {

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -57,6 +57,32 @@ For the example above, `./dist/client/index.js` maps to `src/index.ts` and produ
 
 If an export does not have a matching SSR export, only the browser build is generated for that entrypoint.
 
+### Server preparation
+
+An SSR-enabled entrypoint can prepare properties before rendering by adding an
+adjacent `.ssr` module. For `src/index.ts`, create `src/index.ssr.ts` and export
+an `SsrPrepare` function as the default export:
+
+```ts
+import type { SsrPrepare } from "@svebcomponents/ssr";
+
+const prepare: SsrPrepare = ({ props, setProperty }) => {
+  if (props.data !== undefined || typeof props.source !== "string") return;
+
+  return fetchData(props.source).then((data) => {
+    setProperty("data", data);
+  });
+};
+
+export default prepare;
+```
+
+The build discovers this file automatically and includes it only in the server
+output. Properties set by the hook participate in rich-property serialization,
+so hydratable components receive the prepared value without repeating the work
+in the browser. Return synchronously when no preparation is needed to preserve
+the synchronous SSR path; a returned promise requires an async-capable host.
+
 ## Svelte Conditional Exports
 
 The `svelte` condition provides a lighter build for consumers that already use
@@ -165,6 +191,9 @@ The SSR build uses:
 1. `@svebcomponents/ssr`'s tsdown config helper
 2. Svelte compiled with `generate: "server"`
 3. a generated `ElementRenderer` entrypoint for server-side rendering
+
+If an adjacent `entry.ssr.ts` or `entry.ssr.js` file exists, it is compiled as
+an additional server-only entry and wired into the generated renderer.
 
 When a Svelte-aware SSR build is generated, it also externalizes `svelte` and
 `svelte/*` imports and generates its renderer against the Svelte-aware client

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -1,8 +1,23 @@
-import { expect, test, describe } from "vitest";
+import {
+  beforeEach,
+  expect,
+  test,
+  describe,
+  vi,
+  type MockedFunction,
+} from "vitest";
 import { defineConfig } from "./index";
 import type { Options } from "tsdown";
+import fs from "node:fs";
+
+vi.mock("node:fs");
+const mockExistsSync = fs.existsSync as MockedFunction<typeof fs.existsSync>;
 
 describe("defineConfig", () => {
+  beforeEach(() => {
+    mockExistsSync.mockReset();
+    mockExistsSync.mockReturnValue(false);
+  });
   test("returns default config with client build only when ssr is false", () => {
     const config = defineConfig({ ssr: false });
 
@@ -80,6 +95,20 @@ describe("defineConfig", () => {
 
     expect(config[0]).toHaveProperty("entry", customEntry);
     expect(config[1]).toHaveProperty("entry", customEntry);
+  });
+
+  test("automatically includes an adjacent SSR preparation module", () => {
+    mockExistsSync.mockImplementation(
+      (candidate) => String(candidate) === "src/index.ssr.ts",
+    );
+
+    const config = defineConfig();
+
+    expect(config[0]).toHaveProperty("entry", "src/index.ts");
+    expect(config[1]).toHaveProperty("entry", {
+      index: "src/index.ts",
+      "index.ssr": "src/index.ssr.ts",
+    });
   });
 
   test("derives the hydration host output name from the ssr entry filename", () => {

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -3,6 +3,7 @@ import svebcomponentsSsr, {
 } from "@svebcomponents/ssr/tsdown";
 
 import { createTsdownConfig } from "./svebcomponentConfig.js";
+import { existsSync } from "node:fs";
 import { Options } from "tsdown";
 import path from "node:path";
 import type { SvelteBuildConfig } from "@svebcomponents/ssr/svelte-config";
@@ -63,6 +64,18 @@ const entryOutputFile = (outDir: string, entry: string) =>
     `${path.posix.basename(entry, path.posix.extname(entry))}.js`,
   );
 
+/**
+ * An adjacent `<entry>.ssr.<ext>` module is a server-only preparation hook.
+ * Keeping the extension the same makes the convention predictable for both
+ * TypeScript and JavaScript package sources.
+ */
+const inferSsrPrepareEntry = (entry: string): string | undefined => {
+  const extension = path.posix.extname(entry);
+  if (!extension) return undefined;
+  const candidate = `${entry.slice(0, -extension.length)}.ssr${extension}`;
+  return existsSync(candidate) ? candidate : undefined;
+};
+
 export const defineConfig = (options: DefineConfigOptions = {}) => {
   const { ssr = true, entry = "src/index.ts", svelteConfig } = options;
   const outDir = options.outDir ?? "dist/client";
@@ -70,6 +83,10 @@ export const defineConfig = (options: DefineConfigOptions = {}) => {
   const ssrOutDir = options.ssrOutDir ?? "dist/server";
   const ssrSvelteOutDir = options.ssrSvelteOutDir;
   const ssrEntryFileName = options.ssrEntryFileName ?? "ssr";
+  const prepareEntry = ssr ? inferSsrPrepareEntry(entry) : undefined;
+  const prepareImportPath = prepareEntry
+    ? `./${path.posix.basename(entryOutputFile(ssrOutDir, prepareEntry))}`
+    : undefined;
   // hydration only makes sense when there is server-rendered output to hydrate
   const hydratable = ssr && (options.hydratable ?? true);
   const hydrationHostEntryName = `${ssrEntryFileName}-hydration-host`;
@@ -110,6 +127,9 @@ export const defineConfig = (options: DefineConfigOptions = {}) => {
         ...(hydratable
           ? { hydrationHostImportPath: `./${hydrationHostEntryName}.js` }
           : {}),
+        ...(prepareEntry && prepareImportPath
+          ? { prepareEntry, prepareImportPath }
+          : {}),
       }),
     );
 
@@ -140,6 +160,9 @@ export const defineConfig = (options: DefineConfigOptions = {}) => {
           ),
           ...(hydratable
             ? { hydrationHostImportPath: `./${hydrationHostEntryName}.js` }
+            : {}),
+          ...(prepareEntry && prepareImportPath
+            ? { prepareEntry, prepareImportPath }
             : {}),
         }),
       );

--- a/packages/build/src/inferComponents.test.ts
+++ b/packages/build/src/inferComponents.test.ts
@@ -11,6 +11,12 @@ const mockFs = fs as unknown as {
   existsSync: MockedFunction<typeof fs.existsSync>;
 };
 
+const mockComponentEntriesOnly = () => {
+  mockFs.existsSync.mockImplementation(
+    (candidate) => !String(candidate).match(/\.ssr\.[cm]?[jt]s$/),
+  );
+};
+
 vi.mock("fs/promises", () => ({
   default: { writeFile: vi.fn() },
 }));
@@ -188,12 +194,12 @@ const expectConfigsToMatch = (
 
 describe("infer components", () => {
   it("parses components from package.json", () => {
-    mockFs.existsSync.mockReturnValue(true);
+    mockComponentEntriesOnly();
     const inferredComponents = inferComponents(packageJson);
     expectConfigsToMatch(inferredComponents, manualConfig, [clientPipeline]);
   });
   it("parses SSR components from package.json", () => {
-    mockFs.existsSync.mockReturnValue(true);
+    mockComponentEntriesOnly();
     const inferredComponents = inferComponents(ssrPackageJson);
     expectConfigsToMatch(inferredComponents, manualSSRConfig, [
       clientPipeline,
@@ -202,7 +208,7 @@ describe("infer components", () => {
     ]);
   });
   it("parses Svelte conditional exports from package.json", () => {
-    mockFs.existsSync.mockReturnValue(true);
+    mockComponentEntriesOnly();
     const inferredComponents = inferComponents(svelteConditionPackageJson);
     expectConfigsToMatch(inferredComponents, manualSvelteConditionConfig, [
       clientPipeline,
@@ -214,7 +220,7 @@ describe("infer components", () => {
     ]);
   });
   it("parses multiple components from package.json", () => {
-    mockFs.existsSync.mockReturnValue(true);
+    mockComponentEntriesOnly();
     const inferredComponents = inferComponents(multipleComponentsPackageJson);
     expectConfigsToMatch(inferredComponents, manualMultipleComponentsConfig, [
       clientPipeline,
@@ -224,7 +230,7 @@ describe("infer components", () => {
     ]);
   });
   it("generates the SSR entry filename from the declared ssr export", async () => {
-    mockFs.existsSync.mockReturnValue(true);
+    mockComponentEntriesOnly();
     const inferredComponents = inferComponents(multipleComponentsPackageJson);
     const generated = await collectGeneratedSsrFiles(inferredComponents);
     // The `./componentA/ssr` export declares `./dist/server/componentA-ssr.js`,
@@ -239,7 +245,7 @@ describe("infer components", () => {
     expect(generated).not.toContain(path.resolve("dist/server", "ssr.js"));
   });
   it("keeps the default 'ssr' entry filename for single components", async () => {
-    mockFs.existsSync.mockReturnValue(true);
+    mockComponentEntriesOnly();
     const inferredComponents = inferComponents(ssrPackageJson);
     const generated = await collectGeneratedSsrFiles(inferredComponents);
     expect(generated).toContain(path.resolve("dist/server", "ssr.js"));
@@ -254,7 +260,7 @@ describe("infer components", () => {
     // generated import specifiers, so they must never contain backslashes,
     // even when this code runs on Windows (guards against a regression where
     // `path.normalize` re-introduces platform-native separators).
-    mockFs.existsSync.mockReturnValue(true);
+    mockComponentEntriesOnly();
     const inferredComponents = inferComponents(svelteConditionPackageJson);
     // stringify the whole config graph so every path-bearing field is checked
     const serialized = JSON.stringify(inferredComponents);

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -46,6 +46,12 @@ Expose it from your component package:
 
 The browser entrypoint defines the custom element. The SSR entrypoint provides the renderer an app can register on the server.
 
+When using `@svebcomponents/build`, an adjacent server module such as
+`src/index.ssr.ts` is discovered automatically. Its default `SsrPrepare` export
+runs after host attributes and properties have been applied but before the
+component renders. Values written with `setProperty` are serialized into
+hydratable output for reuse in the browser.
+
 If the package's Svelte config enables Svelte async rendering, the generated
 `./ssr` renderer can yield async Lit `RenderResult` chunks. Async-capable host
 integrations should use the async Vite wrapper below.
@@ -127,6 +133,10 @@ The registry is designed for the Svelte-generated renderers produced by this pac
 A base renderer for Svelte custom elements.
 
 It creates the client custom element class, applies incoming attributes/properties, and renders the server Svelte component with `svelte/server`. Generated SSR entrypoints extend this class.
+
+Its optional `SsrPrepare` hook receives a read-only property snapshot and a
+`setProperty` callback. Synchronous hooks preserve synchronous rendering;
+promise-returning hooks require an async-capable host integration.
 
 ### `installShim`
 

--- a/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.test.ts
+++ b/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.test.ts
@@ -115,6 +115,54 @@ describe("pluginGenerateSsrEntry", () => {
     );
   });
 
+  test("imports and passes an SSR preparation function when provided", async () => {
+    const plugin = pluginGenerateSsrEntry({
+      hydrationHostImportPath: "./hydration-host.js",
+      prepareImportPath: "./index.ssr.js",
+    }) as {
+      writeBundle: FunctionPluginHooks["writeBundle"];
+    };
+    const mockContext = { error: vi.fn() } as unknown as PluginContext;
+    const outputOptions = {
+      dir: "dist/server",
+    } as NormalizedOutputOptions;
+
+    await plugin.writeBundle.call(mockContext, outputOptions, outputBundle);
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/ssr.js"),
+      expect.stringContaining("import prepare from './index.ssr.js'"),
+    );
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/ssr.js"),
+      expect.stringContaining(
+        "super(ServerSvelteComponent, ctor, tagName, HydrationHostComponent, prepare)",
+      ),
+    );
+  });
+
+  test("passes preparation without requiring a hydration host", async () => {
+    const plugin = pluginGenerateSsrEntry({
+      prepareImportPath: "./index.ssr.js",
+    }) as {
+      writeBundle: FunctionPluginHooks["writeBundle"];
+    };
+    const mockContext = { error: vi.fn() } as unknown as PluginContext;
+
+    await plugin.writeBundle.call(
+      mockContext,
+      { dir: "dist/server" } as NormalizedOutputOptions,
+      outputBundle,
+    );
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining("dist/server/ssr.js"),
+      expect.stringContaining(
+        "super(ServerSvelteComponent, ctor, tagName, undefined, prepare)",
+      ),
+    );
+  });
+
   test("uses a custom entry filename when provided", async () => {
     const plugin = pluginGenerateSsrEntry({
       entryFileName: "button-ssr",

--- a/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts
+++ b/packages/ssr/src/lib/rollup/pluginGenerateSsrEntry.ts
@@ -21,6 +21,11 @@ interface GenerateSsrEntryPluginOptions {
    * what the client-side `hydratable` wrapper hydrates.
    */
   hydrationHostImportPath?: string;
+  /**
+   * Import path (relative to the generated entry) of an optional server-only
+   * SSR preparation function.
+   */
+  prepareImportPath?: string;
 }
 
 /**
@@ -36,6 +41,7 @@ export function pluginGenerateSsrEntry(
     clientImportPath = "../client/index.js",
     entryFileName = DEFAULT_ENTRY_FILE_NAME,
     hydrationHostImportPath,
+    prepareImportPath,
   } = options;
 
   return {
@@ -71,7 +77,7 @@ ${
   hydrationHostImportPath
     ? `import HydrationHostComponent from '${hydrationHostImportPath}';\n`
     : ""
-}
+}${prepareImportPath ? `import prepare from '${prepareImportPath}';\n` : ""}
 // Import the client bundle dynamically instead of statically: bundlers that
 // code-split (e.g. rollup in a SvelteKit server build) may hoist a statically
 // imported module into a shared chunk that executes before this module's own
@@ -88,7 +94,7 @@ class ComponentSpecificSvelteCustomElementRenderer extends SvelteCustomElementRe
   constructor(tagName) {
     super(ServerSvelteComponent, ctor, tagName${
       hydrationHostImportPath ? ", HydrationHostComponent" : ""
-    });
+    }${prepareImportPath ? `${hydrationHostImportPath ? "" : ", undefined"}, prepare` : ""});
   }
 }
 

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.test.ts
@@ -314,6 +314,79 @@ describe("SvelteCustomElementRenderer", () => {
     expect(shadowContent).toContain("<div>Test content</div>");
   });
 
+  test("prepares properties synchronously before rendering", () => {
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: { source: "initial" },
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+    const prepare = vi.fn(({ props, setProperty }) => {
+      expect(props).toEqual({ source: "initial" });
+      setProperty("prepared", { value: true });
+    });
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock host component
+      {} as any,
+      prepare,
+    );
+
+    const result = renderer.renderShadow({} as RenderInfo);
+    assert(result);
+    const chunks = Array.from(result);
+
+    expect(chunks.every((chunk) => typeof chunk === "string")).toBe(true);
+    expect(mockRender).toHaveBeenCalledWith(expect.anything(), {
+      props: expect.objectContaining({
+        __initialProps: {
+          source: "initial",
+          prepared: { value: true },
+        },
+      }),
+    });
+    expect(chunks.join("")).toContain(
+      'data-svebcomponents-ssr-props>{"prepared":{"value":true}}</script>',
+    );
+  });
+
+  test("awaits asynchronous property preparation before rendering", async () => {
+    const mockElement = {
+      attributes: {},
+      attributeChangedCallback: vi.fn(),
+      $$d: { source: "initial" },
+      $$p_d: {},
+    };
+    mockClientElementCtor.mockReturnValue(mockElement);
+    const prepare = vi.fn(({ setProperty }) =>
+      Promise.resolve().then(() => setProperty("prepared", "async")),
+    );
+    const renderer = new SvelteCustomElementRenderer(
+      mockSvelteComponent,
+      mockClientElementCtor,
+      tagName,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mock host component
+      {} as any,
+      prepare,
+    );
+
+    const result = renderer.renderShadow({} as RenderInfo);
+    assert(result);
+    const shadow = await collectResult(result);
+
+    expect(mockRender).toHaveBeenCalledWith(expect.anything(), {
+      props: expect.objectContaining({
+        __initialProps: { source: "initial", prepared: "async" },
+      }),
+    });
+    expect(shadow).toContain(
+      'data-svebcomponents-ssr-props>{"prepared":"async"}</script>',
+    );
+  });
+
   test("handles empty render result", async () => {
     mockRender.mockReturnValue(
       Promise.resolve({

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
@@ -24,6 +24,22 @@ type SvelteRenderResult = {
   head: string;
 };
 
+export interface SsrPrepareContext {
+  /** Snapshot of the properties that will be passed to the server component. */
+  readonly props: Readonly<Record<string, unknown>>;
+  /**
+   * Adds or replaces a property before rendering. In hydratable builds, rich
+   * values set here are serialized for the client just like host-supplied
+   * properties.
+   */
+  setProperty(name: string, value: unknown): void;
+}
+
+/** Optional server-only preparation performed before a custom element renders. */
+export type SsrPrepare = (
+  context: SsrPrepareContext,
+) => void | PromiseLike<void>;
+
 /**
  * Since svelte 5.36, `render()` returns a lazily-evaluated `RenderOutput`
  * that is *always* thenable — even for fully synchronous components. Its
@@ -92,6 +108,11 @@ export class SvelteCustomElementRenderer
      * directly as before.
      */
     private hydrationHostComponent?: Component,
+    /**
+     * Optional server-only preparation hook. A synchronous return keeps the
+     * renderer synchronous; returning a promise requires an async-capable host.
+     */
+    private prepare?: SsrPrepare,
   ) {
     super(tagName);
     this.svelteClientCustomElement = new SvelteClientCustomElementCtor();
@@ -191,7 +212,26 @@ export class SvelteCustomElementRenderer
     return `<script type="application/json" data-svebcomponents-ssr-props>${json.replaceAll("<", "\\u003C")}</script>`;
   }
 
-  override *renderShadow(_renderInfo: RenderInfo): RenderResult | undefined {
+  override *renderShadow(renderInfo: RenderInfo): RenderResult | undefined {
+    const preparation = this.prepare?.({
+      props: Object.freeze({ ...this.svelteClientCustomElement.$$d }),
+      setProperty: (name, value) => this.setProperty(name, value),
+    });
+
+    if (isPromiseLike<void>(preparation)) {
+      yield Promise.resolve(preparation).then(() =>
+        Array.from(this.renderPreparedShadow(renderInfo)),
+      );
+      return;
+    }
+
+    yield* this.renderPreparedShadow(renderInfo);
+  }
+
+  /** Renders after any component-specific server preparation has completed. */
+  private *renderPreparedShadow(
+    _renderInfo: RenderInfo,
+  ): Exclude<RenderResult, undefined> {
     const result = (this.hydrationHostComponent
       ? render(this.hydrationHostComponent, {
           props: {

--- a/packages/ssr/src/lib/tsdown/svebcomponentsSsrConfig.test.ts
+++ b/packages/ssr/src/lib/tsdown/svebcomponentsSsrConfig.test.ts
@@ -23,4 +23,18 @@ describe("svebcomponentsSsrConfig", () => {
 
     expect(config.outDir).toEqual(outDir);
   });
+
+  test("compiles a server preparation module as an additional entry", () => {
+    const config = svebcomponentsSsrConfig({
+      entry: "src/index.ts",
+      prepareEntry: "src/index.ssr.ts",
+      prepareImportPath: "./index.ssr.js",
+      outDir: "dist/server",
+    });
+
+    expect(config.entry).toEqual({
+      index: "src/index.ts",
+      "index.ssr": "src/index.ssr.ts",
+    });
+  });
 });

--- a/packages/ssr/src/lib/tsdown/svebcomponentsSsrConfig.ts
+++ b/packages/ssr/src/lib/tsdown/svebcomponentsSsrConfig.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import path from "node:path";
 
 import type { Options } from "tsdown";
 import svelte from "rollup-plugin-svelte";
@@ -54,8 +55,15 @@ interface SvebcomponentsSsrOptions {
    * the client-side `hydratable` wrapper.
    */
   hydrationHostImportPath?: string;
+  /** Server-only preparation module compiled alongside the component. */
+  prepareEntry?: string;
+  /** Import path from the generated renderer entry to the preparation module. */
+  prepareImportPath?: string;
   svelteConfig?: SvelteBuildConfig | undefined;
 }
+
+const entryName = (entry: string) =>
+  path.posix.basename(entry, path.posix.extname(entry));
 
 const createSsrTsdownConfig = ({
   entry,
@@ -65,10 +73,17 @@ const createSsrTsdownConfig = ({
   clientImportPath,
   ssrEntryFileName,
   hydrationHostImportPath,
+  prepareEntry,
+  prepareImportPath,
   svelteConfig,
 }: SvebcomponentsSsrOptions) =>
   ({
-    entry,
+    entry: prepareEntry
+      ? {
+          [entryName(entry)]: entry,
+          [entryName(prepareEntry)]: prepareEntry,
+        }
+      : entry,
     outDir,
     dts: true,
     // Several component configs may share an output directory and are built
@@ -102,6 +117,7 @@ const createSsrTsdownConfig = ({
         ...(hydrationHostImportPath !== undefined
           ? { hydrationHostImportPath }
           : {}),
+        ...(prepareImportPath !== undefined ? { prepareImportPath } : {}),
       }),
     ],
   }) satisfies Options;


### PR DESCRIPTION
## Summary

- automatically discover adjacent entry.ssr.ts modules during svebcomponents builds
- run synchronous or asynchronous server-only prepare hooks before custom-element SSR
- serialize properties set by prepare hooks for client hydration
- add unit and end-to-end coverage, documentation, and a minor changeset

## Verification

- corepack pnpm --filter @svebcomponents/build... build
- corepack pnpm --filter @svebcomponents/e2e.ssr build
- full @svebcomponents/ssr and @svebcomponents/build test suites
- full SSR end-to-end suite
- affected package checks and lint/format
- git diff --check