### PR TITLE
fix: use pathToFileUrl for windows builds and portable config types

### DIFF
--- a/.changeset/fuzzy-pandas-build.md
+++ b/.changeset/fuzzy-pandas-build.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/build": patch
+---
+
+Fix the CLI entry point on Windows by converting its absolute path to a file URL before importing it. Align `tsdown` with consumer installations through a peer dependency and make the `defineConfig` return type explicit so exported configs have portable declaration types.

--- a/packages/build/bin.js
+++ b/packages/build/bin.js
@@ -2,11 +2,12 @@
 // stable entry point for CLI (so pnpm can symlink it even before build)
 import path from "path";
 import fs from "fs";
+import { pathToFileURL } from "node:url";
 
 const distPath = path.resolve(import.meta.dirname, "dist/cli.js");
 
 if (fs.existsSync(distPath)) {
-  await import(distPath);
+  await import(pathToFileURL(distPath).href);
 } else {
   console.error("[svebcomponents]: cli tool not yet built.");
   process.exit(1);

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -48,15 +48,18 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "rolldown": "catalog:"
+    "rolldown": "catalog:",
+    "tsdown": "catalog:"
+  },
+  "peerDependencies": {
+    "tsdown": ">=0.15.0"
   },
   "dependencies": {
     "@sveltejs/load-config": "catalog:",
     "@svebcomponents/auto-options": "workspace:*",
     "@svebcomponents/ssr": "workspace:*",
     "rollup-plugin-svelte": "catalog:",
-    "unconfig": "catalog:",
-    "tsdown": "catalog:"
+    "unconfig": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -63,7 +63,7 @@ const entryOutputFile = (outDir: string, entry: string) =>
     `${path.posix.basename(entry, path.posix.extname(entry))}.js`,
   );
 
-export const defineConfig = (options: DefineConfigOptions = {}) => {
+export const defineConfig = (options: DefineConfigOptions = {}): Options[] => {
   const { ssr = true, entry = "src/index.ts", svelteConfig } = options;
   const outDir = options.outDir ?? "dist/client";
   const svelteOutDir = options.svelteOutDir;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,9 +413,6 @@ importers:
       rollup-plugin-svelte:
         specifier: 'catalog:'
         version: 7.2.3(rollup@4.62.2)(svelte@5.56.4(@typescript-eslint/types@8.29.1))
-      tsdown:
-        specifier: 'catalog:'
-        version: 0.15.12(publint@0.3.21)(typescript@5.8.3)
       unconfig:
         specifier: 'catalog:'
         version: 7.3.2
@@ -441,6 +438,9 @@ importers:
       svelte:
         specifier: 'catalog:'
         version: 5.56.4(@typescript-eslint/types@8.29.1)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.15.12(publint@0.3.21)(typescript@5.8.3)
       typescript:
         specifier: 'catalog:'
         version: 5.8.3


### PR DESCRIPTION
Closes #113.

## What changed

- convert the CLI's absolute entry path to a `file:` URL before dynamically importing it, so Windows drive-letter paths are accepted by Node's ESM loader
- expose `tsdown` as a peer dependency (while retaining it as a development dependency) so `defineConfig` and consumer projects resolve the same `Options` type
- explicitly annotate `defineConfig` as returning `Options[]`
- add a patch changeset for `@svebcomponents/build`

## Root cause

The CLI passed a Windows absolute path such as `C:\\...\\dist\\cli.js` directly to `import()`, which Node interpreted as the unsupported `c:` URL scheme. Separately, pnpm could install a private copy of `tsdown` under `@svebcomponents/build`, making inferred consumer declaration types reference a non-portable nested dependency path.

## Validation

- `corepack pnpm --filter @svebcomponents/build... build`
- `corepack pnpm --filter @svebcomponents/build test` (17 tests)
- `corepack pnpm --filter @svebcomponents/build lint`
- `node --check packages/build/bin.js`
