### PR TITLE
fix(ssr): install DOM shim from Server/AsyncServer wrapper directly

### DIFF
--- a/.changeset/five-plums-shim.md
+++ b/.changeset/five-plums-shim.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+`Server.svelte`/`AsyncServer.svelte` now install the DOM shim themselves as their first import, instead of depending on the consuming app happening to import `@svebcomponents/ssr` before anything else renders. These wrapper components — the ones Vite's dev-time transform and the generated production SSR entry actually load on every custom-element render — previously imported runtime modules directly and never triggered the package's own shim-install side effect, relying entirely on the consuming app's own import order. `installShim`'s effects are idempotent, so this is safe to run alongside any existing manual shim import too.

--- a/packages/ssr/src/lib/vite/AsyncServer.svelte
+++ b/packages/ssr/src/lib/vite/AsyncServer.svelte
@@ -1,4 +1,11 @@
 <script lang="ts">
+  // Installed first, before any other import: this wrapper is what Vite's
+  // dev-time transform (and the generated production SSR entry) always
+  // loads before a custom element renders, so shim installation must not
+  // depend on some other module (e.g. the consuming app's own server hook)
+  // happening to import `@svebcomponents/ssr` first. installShim's effects
+  // are idempotent, so this is safe to run alongside that too.
+  import "../runtime/installShim.js";
   import type { Snippet } from "svelte";
   import { isKebabCase, camelizeKebabCase } from "@svebcomponents/utils";
   import { collectResult } from "@lit-labs/ssr/lib/render-result.js";

--- a/packages/ssr/src/lib/vite/Server.svelte
+++ b/packages/ssr/src/lib/vite/Server.svelte
@@ -1,4 +1,11 @@
 <script lang="ts">
+  // Installed first, before any other import: this wrapper is what Vite's
+  // dev-time transform (and the generated production SSR entry) always
+  // loads before a custom element renders, so shim installation must not
+  // depend on some other module (e.g. the consuming app's own server hook)
+  // happening to import `@svebcomponents/ssr` first. installShim's effects
+  // are idempotent, so this is safe to run alongside that too.
+  import "../runtime/installShim.js";
   import type { Snippet } from "svelte";
   import { isKebabCase, camelizeKebabCase } from "@svebcomponents/utils";
   import { collectResultSync } from "@lit-labs/ssr/lib/render-result.js";


### PR DESCRIPTION
## Summary
- `Server.svelte`/`AsyncServer.svelte` — the wrapper components Vite's dev-time transform (and the generated production SSR entry) actually load on every custom-element render — now install the DOM shim themselves as their first import.
- They previously imported runtime modules via direct relative paths and never triggered the package's own shim-install side effect (that only lived behind the package's `index.ts` barrel import). Shim installation therefore depended entirely on the consuming app's `hooks.server.ts` happening to import `@svebcomponents/ssr` before anything else renders — pure import-order luck, not a guarantee, and exactly the kind of ordering a different module runner (or a bundler) can break.
- `installShim`'s effects are already idempotent, so this is safe alongside any existing shim import elsewhere.

Found dogfooding `@svebcomponents/ssr` against a real SvelteKit app, where this surfaced as "the DOM shim doesn't reliably install" under a newer Vite's SSR module runner. Part 2 of 3 split PRs for that investigation.

## Test plan
- [x] `pnpm --filter @svebcomponents/ssr test` — 95 tests pass
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] Changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)