### PR TITLE
fix(build): bundle the ssr HydrationHost into hydratable client builds

### DIFF
--- a/.changeset/hydration-host-client-bundle.md
+++ b/.changeset/hydration-host-client-bundle.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/build": patch
+---
+
+The client build of a hydratable component now bundles `@svebcomponents/ssr`'s `HydrationHost` (compiled by the component's own toolchain, exactly like the server-side host) instead of leaving `import ... from "@svebcomponents/ssr/hydration-host"` as an external runtime import. That subpath ships as raw `.svelte`, so an external import resolved to an uncompiled `.svelte` at runtime — which a consuming app's SSR could only load by adding every such component to `ssr.noExternal`. With the host bundled, consuming apps no longer need a per-component `ssr.noExternal` entry. Hydration markers still match by construction because both the client and server host are compiled by the same (component author's) build.

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -89,6 +89,24 @@ describe("defineConfig", () => {
     expect(config[1]).toHaveProperty("outDir", "dist/server");
   });
 
+  test("bundles the ssr HydrationHost into the client build when hydratable", () => {
+    // otherwise the injected `import ... from "@svebcomponents/ssr/hydration-host"`
+    // stays external and resolves to raw .svelte at runtime, forcing every
+    // consuming app to add the component to ssr.noExternal
+    const config = defineConfig({ hydratable: true });
+
+    expect(config[0]).toHaveProperty("outDir", "dist/client");
+    expect(config[0]).toHaveProperty("noExternal", [
+      /@svebcomponents\/ssr\/hydration-host/,
+    ]);
+  });
+
+  test("does not force-bundle the hydration host for a non-hydratable client build", () => {
+    const config = defineConfig({ hydratable: false });
+
+    expect(config[0]).not.toHaveProperty("noExternal");
+  });
+
   test("returns all configs by default (ssr and hydratable default to true)", () => {
     const config = defineConfig();
 

--- a/packages/build/src/svebcomponentConfig.ts
+++ b/packages/build/src/svebcomponentConfig.ts
@@ -92,6 +92,19 @@ export const createTsdownConfig = (options: SvebcomponentsOptions): Options => {
         }
       : {}),
     ...(externalSvelte ? { external: [/^svelte(\/.*)?$/] } : {}),
+    // A hydratable component's client build imports `@svebcomponents/ssr`'s
+    // HydrationHost (see auto-options' injected `import ... from
+    // "@svebcomponents/ssr/hydration-host"`). That subpath ships as raw
+    // `.svelte`, so leaving it external forces the runtime import to resolve
+    // to an uncompiled `.svelte` — which a consuming app's SSR can only load
+    // if it adds every such component to `ssr.noExternal`. Bundle it here
+    // instead: it is compiled by this same (component author's) toolchain,
+    // exactly like the server-side host (see `createHydrationHostTsdownConfig`),
+    // so hydration markers still match by construction and consumers need no
+    // `noExternal` entry for the component.
+    ...(hydratable
+      ? { noExternal: [/@svebcomponents\/ssr\/hydration-host/] }
+      : {}),
     plugins: [
       ...(externalSvelte ? [] : [pluginDedupe(["svelte", "esm-env"])]),
       autoOptions({ hydratable }),


### PR DESCRIPTION
## Problem

A hydratable component's **client** build imports `@svebcomponents/ssr`'s `HydrationHost` via the auto-options-injected import:

```js
import { hydratable as … } from "@svebcomponents/ssr/hydration";
import … from "@svebcomponents/ssr/hydration-host";   // ← ships as raw .svelte
```

`./hydration-host` ships as raw `.svelte`. When `@svebcomponents/ssr` is a **peer** dep (the normal setup for a published component), the client build externalizes that import — so at runtime it resolves to an *uncompiled* `.svelte`. A consuming app's SSR then can't load it (`ERR_UNKNOWN_FILE_EXTENSION`).

Crucially, the consumer **can't** fix this with `ssr.noExternal: ['@svebcomponents/ssr']`: the raw `.svelte` is reached *through* the externalized component package, and `noExternal` doesn't follow into an external package's subtree. So today the consumer is forced to also list **every such component**:

```js
ssr: { noExternal: ['@svebcomponents/atproto.comments'] }   // ← the per-component tax
```

(The plugin's own `config()` already auto-adds `@svebcomponents/ssr` — verified working under Vite 8 — which covers the consumer-injected wrappers. It just can't reach the transitively-imported host.)

The **server** side already avoids the whole problem: `createHydrationHostTsdownConfig` compiles the host into the component's own `dist/server`. The client side just never got the equivalent.

## Fix

Force-bundle `@svebcomponents/ssr/hydration-host` into the client build (single `noExternal` entry, gated on `hydratable`). It's then compiled by the component's **own** toolchain — the same one that builds the server-side host — so:

- no raw `.svelte` is imported at runtime → **consumers need no per-component `noExternal`** (and, since the plugin already handles `@svebcomponents/ssr`, no manual `ssr.noExternal` at all);
- hydration markers still match by construction (both sides compiled by the same build), preserving the guarantee `HydrationHost.svelte`'s own comment calls out.

## Verification

`e2e/ssr`, with `@svebcomponents/ssr` moved to a **peer** dep (reproducing a real published component):

| | `dist/client` imports |
|---|---|
| **before** | `@svebcomponents/ssr/hydration-host` (raw `.svelte`) |
| **after** | host inlined & compiled; only the plain-`.js` `/hydration` + banner `/shim` remain |

All `e2e/ssr` tests pass in both setups, including the **chromium** hydration tests (9/9). Added unit coverage in `packages/build`; `build`/`lint`/`check`/`test` all green.

Separately confirmed against a real consuming SvelteKit app (Vite 8, prerender): the plugin's auto-`noExternal` for `@svebcomponents/ssr` already covers the wrappers, so once a component carries this fix the consumer needs no `ssr.noExternal` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)