### PR TITLE
fix(ssr): support renderers across module instances

### DIFF
--- a/.changeset/tidy-spiders-render.md
+++ b/.changeset/tidy-spiders-render.md
@@ -1,0 +1,5 @@
+---
+"@svebcomponents/ssr": patch
+---
+
+SSR wrappers now recognize `SvelteCustomElementRenderer` subclasses across separate bundled and external module instances. A consuming app can leave a normally compiled svebcomponent external without the wrapper's nominal `instanceof` check rejecting its registered renderer, so the component package no longer needs its own `ssr.noExternal` entry.

--- a/packages/build/CHANGELOG.md
+++ b/packages/build/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- d714a97: The client build of a hydratable component now bundles `@svebcomponents/ssr`'s `HydrationHost` (compiled by the component's own toolchain, exactly like the server-side host) instead of leaving `import ... from "@svebcomponents/ssr/hydration-host"` as an external runtime import. That subpath ships as raw `.svelte`, so an external import resolved to an uncompiled `.svelte` at runtime — which a consuming app's SSR could only load by adding every such component to `ssr.noExternal`. With the host bundled, consuming apps no longer need a per-component `ssr.noExternal` entry. Hydration markers still match by construction because both the client and server host are compiled by the same (component author's) build.
+- d714a97: The client build of a hydratable component now bundles `@svebcomponents/ssr`'s `HydrationHost` (compiled by the component's own toolchain, exactly like the server-side host) instead of leaving `import ... from "@svebcomponents/ssr/hydration-host"` as an external runtime import. That subpath ships as raw `.svelte`, so an external import resolved to an uncompiled `.svelte` at runtime — which a consuming app's SSR could only load by adding every such component to `ssr.noExternal`. Bundling the host removes that raw-`.svelte` reason for a per-component entry; consumers also need an `@svebcomponents/ssr` version whose wrapper recognizes renderers across bundled and external module instances before removing the entry entirely. Hydration markers still match by construction because both the client and server host are compiled by the same (component author's) build.
 
 ## 0.3.0
 

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRenderer.ts
@@ -19,6 +19,16 @@ const isPromiseLike = <T>(value: unknown): value is PromiseLike<T> =>
   "then" in value &&
   typeof value.then === "function";
 
+/**
+ * The Vite wrapper can be bundled while a component's generated `/ssr`
+ * entry stays external. Both evaluate this module independently, so class
+ * identity is not stable across that boundary. A versioned global symbol
+ * describes the renderer contract without making the class itself global.
+ */
+const SVELTE_CUSTOM_ELEMENT_RENDERER_BRAND = Symbol.for(
+  "@svebcomponents/ssr/SvelteCustomElementRenderer/v1",
+);
+
 type SvelteRenderResult = {
   body: string;
   head: string;
@@ -280,3 +290,26 @@ export class SvelteCustomElementRenderer
     this.ssrAttributes.set(attributeName, attributeValue);
   }
 }
+
+Object.defineProperty(
+  SvelteCustomElementRenderer.prototype,
+  SVELTE_CUSTOM_ELEMENT_RENDERER_BRAND,
+  { value: true },
+);
+
+/**
+ * Cross-module-instance type guard for renderers created by this runtime.
+ *
+ * `instanceof SvelteCustomElementRenderer` is only valid when the renderer
+ * and caller imported the same evaluated module instance. Vite SSR may
+ * intentionally mix bundled and external package instances, so wrapper code
+ * must use this contract brand instead.
+ */
+export const isSvelteCustomElementRenderer = (
+  value: unknown,
+): value is SvelteCustomElementRenderer =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as Record<PropertyKey, unknown>)[
+    SVELTE_CUSTOM_ELEMENT_RENDERER_BRAND
+  ] === true;

--- a/packages/ssr/src/lib/runtime/svelteCustomElementRendererIdentity.test.ts
+++ b/packages/ssr/src/lib/runtime/svelteCustomElementRendererIdentity.test.ts
@@ -1,0 +1,41 @@
+import type { Component } from "svelte";
+import { expect, test, vi } from "vitest";
+import type { SvelteClientCustomElement } from "./svelteCustomElementRenderer.js";
+
+const createClientElementCtor = () =>
+  class {
+    attributes = {};
+    attributeChangedCallback() {}
+    $$d = {};
+    $$p_d = {};
+    $$c = {} as Component;
+  } as unknown as { new (): SvelteClientCustomElement };
+
+test("recognizes a renderer created by a separate module instance", async () => {
+  const first = await import("./svelteCustomElementRenderer.js");
+
+  vi.resetModules();
+
+  const second = await import("./svelteCustomElementRenderer.js");
+  const renderer = new second.SvelteCustomElementRenderer(
+    {} as Component,
+    createClientElementCtor(),
+    "test-element",
+  );
+
+  expect(second.SvelteCustomElementRenderer).not.toBe(
+    first.SvelteCustomElementRenderer,
+  );
+  expect(renderer).not.toBeInstanceOf(first.SvelteCustomElementRenderer);
+  expect(first.isSvelteCustomElementRenderer(renderer)).toBe(true);
+});
+
+test("rejects an unbranded renderer-like object", async () => {
+  const { isSvelteCustomElementRenderer } = await import(
+    "./svelteCustomElementRenderer.js"
+  );
+
+  expect(isSvelteCustomElementRenderer({ tagName: "test-element" })).toBe(
+    false,
+  );
+});

--- a/packages/ssr/src/lib/vite/AsyncServer.svelte
+++ b/packages/ssr/src/lib/vite/AsyncServer.svelte
@@ -12,7 +12,7 @@
 
   import { isValidCustomElementTagName } from "../runtime/html.js";
   import { ElementRendererRegistry } from "../runtime/rendererRegistry.js";
-  import { SvelteCustomElementRenderer } from "../runtime/svelteCustomElementRenderer.js";
+  import { isSvelteCustomElementRenderer } from "../runtime/svelteCustomElementRenderer.js";
 
   interface WebComponentWrapperProps {
     children?: Snippet;
@@ -41,7 +41,7 @@
     if (!CustomElementRendererCtor)
       throw new Error(`Custom element renderer for ${tagName} not found`);
     const customElementRenderer = new CustomElementRendererCtor(tagName);
-    if (!(customElementRenderer instanceof SvelteCustomElementRenderer)) {
+    if (!isSvelteCustomElementRenderer(customElementRenderer)) {
       throw new Error(
         `Renderer for ${tagName} must extend SvelteCustomElementRenderer`,
       );

--- a/packages/ssr/src/lib/vite/Server.svelte
+++ b/packages/ssr/src/lib/vite/Server.svelte
@@ -12,7 +12,7 @@
 
   import { isValidCustomElementTagName } from "../runtime/html.js";
   import { ElementRendererRegistry } from "../runtime/rendererRegistry.js";
-  import { SvelteCustomElementRenderer } from "../runtime/svelteCustomElementRenderer.js";
+  import { isSvelteCustomElementRenderer } from "../runtime/svelteCustomElementRenderer.js";
 
   interface WebComponentWrapperProps {
     children?: Snippet;
@@ -41,7 +41,7 @@
     if (!CustomElementRendererCtor)
       throw new Error(`Custom element renderer for ${tagName} not found`);
     const customElementRenderer = new CustomElementRendererCtor(tagName);
-    if (!(customElementRenderer instanceof SvelteCustomElementRenderer)) {
+    if (!isSvelteCustomElementRenderer(customElementRenderer)) {
       throw new Error(
         `Renderer for ${tagName} must extend SvelteCustomElementRenderer`,
       );


### PR DESCRIPTION
## What changed

- Brand `SvelteCustomElementRenderer` prototypes with a versioned `Symbol.for` contract.
- Replace the sync and async wrappers' nominal `instanceof` checks with a cross-module-instance type guard.
- Add a regression test that evaluates the renderer module twice, verifies that the constructors differ and `instanceof` fails, then verifies that the branded guard succeeds.
- Add a patch changeset for `@svebcomponents/ssr`.
- Correct the `@svebcomponents/build` 0.3.1 changelog: bundling `HydrationHost` removed the raw-`.svelte` blocker, but this renderer-instance fix is also required before consumers can remove their component-level `ssr.noExternal` entry entirely.

## Why

A Vite SSR build can bundle the plugin-injected wrapper while leaving a component package's generated `/ssr` entry external. That evaluates `@svebcomponents/ssr` twice. The renderer registry already survives this because it is a `globalThis[Symbol.for(...)]` singleton, but the exported class has per-module identity, so the wrapper rejected a correctly registered renderer with:

`Renderer for <tag> must extend SvelteCustomElementRenderer`

The versioned brand preserves the intended contract across the bundled/external boundary without precompiling the wrapper components against one Svelte compiler version. Consumers can therefore leave normally compiled svebcomponents external and remove their per-component `ssr.noExternal` entry. `@svebcomponents/ssr` itself still remains `noExternal` because its wrapper exports are raw `.svelte` files.

## Tradeoffs

The brand becomes a small compatibility contract: incompatible future renderer shapes must use a new brand version. This is preferable to making the renderer class a global singleton, which would make the first loaded package version silently win, or precompiling the wrappers, which would couple their generated code to Svelte compiler/runtime internals across the package's broad `svelte: ^5` peer range.

The existing automatic `noExternal` rule for `@svebcomponents/ssr`, the explicit plugin option for genuinely raw external Svelte packages, and the HydrationHost client bundling remain necessary.

## Validation

- `vitest run`: 112 tests passed.
- `svelte-check`: 0 errors and 0 warnings.
- ESLint and Prettier passed.
- `svelte-package` and publint passed; publint reports only the pre-existing optional `sideEffects` suggestion.
- Reproduced the original failure in the SvelteKit/Vite 8 `@svebcomponents/atproto.comments` consumer with no component-level `ssr.noExternal`; applying this patch made the same prerender build complete successfully.
