### PR TITLE
fix(build): resolve browser bundles against the production condition

### DIFF
--- a/.changeset/tame-donuts-tickle.md
+++ b/.changeset/tame-donuts-tickle.md
@@ -1,0 +1,9 @@
+---
+"@svebcomponents/build": patch
+---
+
+Resolve browser bundles against the `production` export condition, so Svelte's dev-only code no longer ships to the browser.
+
+Without it, `esm-env` resolved `DEV` through its `dev-fallback` — a runtime `process.env.NODE_ENV` check rather than a literal — so no `if (DEV)` branch in Svelte's runtime could be eliminated and the full dev-only error and warning message texts ended up in the published bundle. Cross-module const inlining is enabled alongside it, since rolldown otherwise emits the resolved `DEV` as a module-level `var` that the minifier will not fold into its use sites.
+
+The e2e `basic` component's client bundle drops from 42.3 kB to 32.6 kB raw (15.9 kB to 12.7 kB gzipped).

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -161,6 +161,22 @@ describe("defineConfig", () => {
     expect(config[1]).toHaveProperty("entry", "src/index.ts");
   });
 
+  test("builds the browser bundles against the production export condition", () => {
+    // `esm-env` otherwise resolves DEV to a runtime `process.env.NODE_ENV`
+    // check, and every `if (DEV)` branch in Svelte's runtime — including the
+    // full error and warning message texts — survives into the browser bundle
+    const config = defineConfig({ svelteOutDir: "dist/client-svelte" });
+
+    for (const clientConfig of [config[0], config[1]]) {
+      expect(clientConfig?.inputOptions).toMatchObject({
+        resolve: { conditionNames: ["production"] },
+        // without inlining, DEV lands as a module-level `var` the minifier
+        // will not fold, and the dead branches stay regardless
+        optimization: { inlineConst: { mode: "smart" } },
+      });
+    }
+  });
+
   test("returns valid tsdownOptions", () => {
     const config = defineConfig();
 

--- a/packages/build/src/svebcomponentConfig.ts
+++ b/packages/build/src/svebcomponentConfig.ts
@@ -69,6 +69,31 @@ export const createTsdownConfig = (options: SvebcomponentsOptions): Options => {
     // in parallel by the svebcomponents CLI; tsdown's per-build clean would
     // race and delete other builds' output. The CLI cleans once up front.
     clean: false,
+    inputOptions: {
+      resolve: {
+        // Svelte gates its error and warning message texts — and a good deal
+        // of extra bookkeeping — behind `if (DEV)`, where `DEV` comes from
+        // `esm-env`. Without the `production` condition `esm-env` resolves to
+        // its `dev-fallback`, which is a *runtime* `process.env.NODE_ENV`
+        // check rather than a literal, so none of those branches can be
+        // eliminated and the full dev-only message texts ship to the browser.
+        //
+        // Listed alone rather than alongside the usual `browser`/`import`
+        // defaults on purpose: rolldown treats these as additive to the ones
+        // `platform` already implies, and naming `browser` here would also
+        // apply it to configs that are not browser builds.
+        conditionNames: ["production"],
+      },
+      optimization: {
+        // The condition alone is not enough. Rolldown emits the resolved
+        // `DEV` as a module-level `var`, which the minifier will not fold
+        // into its use sites, so the dead branches survive anyway. `smart`
+        // mode inlines imported constants exactly where it can decide a
+        // branch (`if`, ternary, `&&`/`||`/`??`) — which is the whole of
+        // what `DEV` is used for.
+        inlineConst: { mode: "smart", pass: 3 },
+      },
+    },
     // Guarantees the DOM shim installs before this module's own compiled
     // custom-element class (`class X extends HTMLElement`) evaluates,
     // regardless of *how* this module ends up reachable on the server (a


### PR DESCRIPTION
## The problem

Svelte gates its error and warning message texts — and a fair amount of extra bookkeeping — behind `if (DEV)`, where `DEV` comes from `esm-env`. `createTsdownConfig` never set the **`production` export condition**, so `esm-env` resolved through its `dev-fallback`:

```js
const node_env = globalThis.process?.env?.NODE_ENV;
export default node_env && !node_env.toLowerCase().startsWith('prod');
```

That is a *runtime* check, not a literal, so no `if (DEV)` branch could be eliminated. Published browser bundles shipped the full dev-only message texts:

```js
function He(e){s?console.warn(`%c[svelte] hydration_mismatch\n%c${e?`Hydration failed because the initial UI does not match what was rendered on the server. The error occurred near ${e}`:`…`}
```

In `@svebcomponents/atproto.comments` that came to ~6 kB raw across `errors.js` and `warnings.js` alone.

## The fix

Two parts, both needed:

1. `resolve.conditionNames: ["production"]` — makes `esm-env` resolve `DEV` to a literal `false`.
2. `optimization.inlineConst` — the condition alone is not enough. Rolldown emits the resolved `DEV` as a module-level `var o = !1` and oxc-minify will not fold that into its use sites, so the dead branches survive anyway. `smart` mode inlines imported constants exactly where they decide a branch (`if`, ternary, `&&`/`||`/`??`), which is the whole of what `DEV` is used for.

`conditionNames` deliberately lists `production` alone rather than alongside the usual `browser`/`import` defaults — rolldown treats these as additive to what `platform` already implies. I tried spelling out `["production", "browser", "svelte", "import", "module", "default"]` first and it inflated the *SSR* bundle of a downstream component from 45 kB to 167 kB by pulling Svelte's client runtime into the server build.

## Impact

e2e `basic` client bundle:

| | raw | gzip |
|---|---|---|
| before | 42.3 kB | 15.9 kB |
| after | **32.6 kB** | **12.7 kB** |
| | −23% | −20% |

Verified downstream against `@svebcomponents/atproto.comments` (a considerably larger real component): 93.6 → 81.3 kB raw, 31.8 → 27.8 kB gzip, and its host SvelteKit app builds and renders unchanged.

## Scope

Client builds only (`createTsdownConfig`). `@svebcomponents/ssr`'s configs have the same gap, but the win there is ~0.4 kB of server-side code — worth a separate look rather than widening this PR.

## Testing

- `pnpm test` — 18/18 tasks, including the Chromium e2e suites; the `ssr` package's hydration tests are the ones that would catch a mis-resolved runtime, and they pass.
- `pnpm lint`, `pnpm check` clean.
- Asserted directly on the built artifact that `%c[svelte]` and `"Svelte error"` no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpWk46Sjx5E5SR12MtBTKs