### PR TITLE
fix(build): bundle the hydratable wrapper into the client build

### DIFF
--- a/.changeset/olive-pears-shave.md
+++ b/.changeset/olive-pears-shave.md
@@ -1,0 +1,9 @@
+---
+"@svebcomponents/build": patch
+---
+
+Bundle the `hydratable` wrapper into a hydratable component's client build, so the Svelte-bundled `dist/client` stays loadable straight from a URL.
+
+auto-options injects `import { hydratable } from "@svebcomponents/ssr/hydration"`, and only its sibling `@svebcomponents/ssr/hydration-host` was forced non-external. A component that declares `@svebcomponents/ssr` as the optional *peer* dependency it is meant to be therefore shipped a bare specifier in an otherwise self-contained bundle — which a browser cannot resolve without an import map, so the custom element never registered. Resolving it via an import map would not have been a fix either: the module imports `svelte`, so it would pull a second Svelte runtime in alongside the one already bundled.
+
+Adds ~2 kB raw to `dist/client` for hydratable components, which is the cost of the bundle actually being self-contained.

--- a/e2e/ssr/package.json
+++ b/e2e/ssr/package.json
@@ -42,5 +42,13 @@
   },
   "dependencies": {
     "@svebcomponents/utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "@svebcomponents/ssr": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@svebcomponents/ssr": {
+      "optional": true
+    }
   }
 }

--- a/e2e/ssr/test/server/selfContainedClientBundle.test.ts
+++ b/e2e/ssr/test/server/selfContainedClientBundle.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { test, expect } from "vitest";
+
+/**
+ * The Svelte-bundled client build (`dist/client`) is the CDN / bare-`import`
+ * drop-in: a browser loads it straight from a URL, with no bundler and no
+ * import map. Every specifier it *statically* imports must therefore be
+ * relative — a bare specifier that survives into this build cannot be
+ * resolved by the browser at all, and the element never registers.
+ *
+ * This package declares `@svebcomponents/ssr` as the optional peer dependency
+ * a real published component is meant to declare, which is what makes the
+ * check meaningful: tsdown externalizes peer dependencies by default, so the
+ * `hydratable`/HydrationHost imports auto-options injects would otherwise
+ * leak out as bare specifiers here.
+ *
+ * `dist/client-svelte` is deliberately not checked — that variant is compiled
+ * into a consuming app's own build, where bare specifiers are the point.
+ */
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const clientDist = path.resolve(dir, "../../dist/client");
+
+// static `import ... from "x"` / `export ... from "x"` only. Dynamic
+// `import("x")` is excluded on purpose: the build's SSR shim guard is a
+// dynamic import behind `typeof window === "undefined"`, so a browser never
+// evaluates it.
+const STATIC_SPECIFIER = /\bfrom\s*["']([^"']+)["']/g;
+
+const isRelative = (specifier: string) =>
+  specifier.startsWith("./") || specifier.startsWith("../");
+
+test.each(readdirSync(clientDist).filter((file) => file.endsWith(".js")))(
+  "dist/client/%s statically imports nothing a browser cannot resolve",
+  (file) => {
+    const code = readFileSync(path.join(clientDist, file), "utf8");
+    const bare = [...code.matchAll(STATIC_SPECIFIER)]
+      .map(([, specifier]) => specifier)
+      .filter((specifier) => specifier !== undefined && !isRelative(specifier));
+
+    expect(bare).toEqual([]);
+  },
+);

--- a/packages/build/src/index.test.ts
+++ b/packages/build/src/index.test.ts
@@ -89,19 +89,26 @@ describe("defineConfig", () => {
     expect(config[1]).toHaveProperty("outDir", "dist/server");
   });
 
-  test("bundles the ssr HydrationHost into the client build when hydratable", () => {
-    // otherwise the injected `import ... from "@svebcomponents/ssr/hydration-host"`
-    // stays external and resolves to raw .svelte at runtime, forcing every
-    // consuming app to add the component to ssr.noExternal
+  test("bundles both ssr hydration imports into the client build when hydratable", () => {
+    // The HydrationHost otherwise stays external and resolves to raw .svelte
+    // at runtime, forcing every consuming app to add the component to
+    // ssr.noExternal; `hydratable` otherwise leaks out as a bare specifier a
+    // browser cannot resolve, because a component declaring
+    // @svebcomponents/ssr as the optional peer dependency it is meant to be
+    // gets peer dependencies externalized by default.
     const config = defineConfig({ hydratable: true });
+    const [noExternal] = config[0]?.noExternal as [RegExp];
 
     expect(config[0]).toHaveProperty("outDir", "dist/client");
-    expect(config[0]).toHaveProperty("noExternal", [
-      /@svebcomponents\/ssr\/hydration-host/,
-    ]);
+    for (const injected of [
+      "@svebcomponents/ssr/hydration",
+      "@svebcomponents/ssr/hydration-host",
+    ]) {
+      expect(noExternal.test(injected)).toBe(true);
+    }
   });
 
-  test("does not force-bundle the hydration host for a non-hydratable client build", () => {
+  test("does not force-bundle the hydration imports for a non-hydratable client build", () => {
     const config = defineConfig({ hydratable: false });
 
     expect(config[0]).not.toHaveProperty("noExternal");

--- a/packages/build/src/svebcomponentConfig.ts
+++ b/packages/build/src/svebcomponentConfig.ts
@@ -117,19 +117,30 @@ export const createTsdownConfig = (options: SvebcomponentsOptions): Options => {
         }
       : {}),
     ...(externalSvelte ? { external: [/^svelte(\/.*)?$/] } : {}),
-    // A hydratable component's client build imports `@svebcomponents/ssr`'s
-    // HydrationHost (see auto-options' injected `import ... from
-    // "@svebcomponents/ssr/hydration-host"`). That subpath ships as raw
-    // `.svelte`, so leaving it external forces the runtime import to resolve
-    // to an uncompiled `.svelte` — which a consuming app's SSR can only load
-    // if it adds every such component to `ssr.noExternal`. Bundle it here
-    // instead: it is compiled by this same (component author's) toolchain,
-    // exactly like the server-side host (see `createHydrationHostTsdownConfig`),
-    // so hydration markers still match by construction and consumers need no
-    // `noExternal` entry for the component.
-    ...(hydratable
-      ? { noExternal: [/@svebcomponents\/ssr\/hydration-host/] }
-      : {}),
+    // A hydratable component's client build imports two things from
+    // `@svebcomponents/ssr` (see auto-options' injected imports): the
+    // `hydratable` wrapper from "@svebcomponents/ssr/hydration", and the
+    // HydrationHost from "@svebcomponents/ssr/hydration-host". Both must be
+    // bundled — the regex below is a substring test, so it covers both
+    // subpaths.
+    //
+    // The host ships as raw `.svelte`, so leaving it external forces the
+    // runtime import to resolve to an uncompiled `.svelte` — which a consuming
+    // app's SSR can only load if it adds every such component to
+    // `ssr.noExternal`. Bundling it here is safe: it is compiled by this same
+    // (component author's) toolchain, exactly like the server-side host (see
+    // `createHydrationHostTsdownConfig`), so hydration markers still match by
+    // construction and consumers need no `noExternal` entry.
+    //
+    // `hydration` is plain JS, but a component that declares
+    // `@svebcomponents/ssr` as the optional *peer* dependency it is meant to
+    // be gets it externalized by default — leaving a bare specifier in a
+    // bundle that is otherwise self-contained. That breaks the CDN drop-in
+    // outright (browsers cannot resolve bare specifiers without an import
+    // map), and resolving it via an import map would be worse still: the
+    // module imports `svelte`, so it would pull a *second* Svelte runtime in
+    // alongside the one already bundled here.
+    ...(hydratable ? { noExternal: [/@svebcomponents\/ssr\/hydration/] } : {}),
     plugins: [
       ...(externalSvelte ? [] : [pluginDedupe(["svelte", "esm-env"])]),
       autoOptions({ hydratable }),


### PR DESCRIPTION
## The bug

auto-options injects **two** imports into a hydratable component's client build:

```js
import { hydratable as __svebcomponentsHydratable } from "@svebcomponents/ssr/hydration";
import __svebcomponentsHydrationHost from "@svebcomponents/ssr/hydration-host";
```

Only the second was covered by `noExternal`. The first leaked out as a bare specifier in `dist/client` — the Svelte-bundled CDN / bare-`import` drop-in:

```js
import{hydratable as e}from"@svebcomponents/ssr/hydration"
```

A browser loading that from a URL cannot resolve a bare specifier, so the module fails and the custom element never registers.

### Why it only bites real components

tsdown externalizes `peerDependencies` by default. A published component declares `@svebcomponents/ssr` as the optional peer dependency it is meant to be — and gets the bare specifier. The `e2e/ssr` fixture declared it as a `devDependency`, so it was bundled incidentally and the suite stayed green.

| | declares `@svebcomponents/ssr` as | `dist/client` |
|---|---|---|
| `e2e/ssr` (before) | `devDependency` | self-contained ✅ |
| a real published component | optional `peerDependency` | **bare specifier** ❌ |

## Why not an import map

It would need to map `svelte` too, since `hydratable.js` does `import { hydrate, unmount } from "svelte"` — pulling a **second Svelte runtime** in alongside the one already bundled into `dist/client`. That is the exact `Cannot read properties of null (reading 'f')` failure #122 and the `svelte`-condition work exist to prevent. It would also put boilerplate in every consumer's HTML, which defeats the point of a drop-in.

## The fix

`noExternal` is a substring test, so dropping `-host` from the pattern covers both subpaths:

```diff
-      ? { noExternal: [/@svebcomponents\/ssr\/hydration-host/] }
+      ? { noExternal: [/@svebcomponents\/ssr\/hydration/] }
```

## Trade-off

`dist/client` grows **~2 kB raw** for hydratable components. That is the cost of the bundle actually being self-contained, and it is not really a regression against a working alternative — the 2 kB smaller version does not load.

`dist/client-svelte` is unaffected in spirit: Svelte stays external there, so the bundled `hydratable` still resolves to the consuming app's single runtime.

## Regression guard

The fixture now declares `@svebcomponents/ssr` as an optional peer dependency, matching a real component, and a new test asserts `dist/client` statically imports nothing a browser cannot resolve. Verified it fails without the fix:

```
- Expected
+ Received

- []
+ [ "@svebcomponents/ssr/hydration" ]
```

It checks static `from "..."` only — the SSR shim guard is a dynamic import behind `typeof window === "undefined"`, which a browser never evaluates. `dist/client-svelte` is deliberately not checked; bare specifiers are the point there.

## Testing

- `pnpm test` 18/18, `pnpm lint`, `pnpm check` clean.
- Verified downstream against `@svebcomponents/atproto.comments`: bare specifiers go to zero, 81.3 → 83.4 kB raw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpWk46Sjx5E5SR12MtBTKs