### PR TITLE
refactor(ssr): extract framework-neutral renderCustomElement

### DIFF
--- a/.changeset/tidy-donkeys-repeat.md
+++ b/.changeset/tidy-donkeys-repeat.md
@@ -1,0 +1,9 @@
+---
+"@svebcomponents/ssr": minor
+---
+
+Extract a host-framework-neutral `renderCustomElement` / `renderCustomElementSync` from the Svelte SSR wrappers.
+
+Both wrappers previously carried an identical copy of the "look up the renderer, apply props, collect declarative shadow DOM" logic, differing only in whether they collected the shadow result synchronously. That logic now lives in `runtime/renderCustomElement.ts` and is exported from the package root, so host integrations for other frameworks can reuse it.
+
+No behavior change for Svelte hosts.

--- a/packages/ssr/src/lib/index.ts
+++ b/packages/ssr/src/lib/index.ts
@@ -2,3 +2,4 @@
 import "./runtime/installShim.js";
 export * from "./runtime/rendererRegistry.js";
 export * from "./runtime/svelteCustomElementRenderer.js";
+export * from "./runtime/renderCustomElement.js";

--- a/packages/ssr/src/lib/runtime/renderCustomElement.test.ts
+++ b/packages/ssr/src/lib/runtime/renderCustomElement.test.ts
@@ -1,0 +1,162 @@
+import { expect, test, describe, beforeEach, vi } from "vitest";
+
+import "./installShim.js";
+import { ElementRendererRegistry } from "./rendererRegistry.js";
+import { SvelteCustomElementRenderer } from "./svelteCustomElementRenderer.js";
+import {
+  renderCustomElement,
+  renderCustomElementSync,
+} from "./renderCustomElement.js";
+
+import { render } from "svelte/server";
+
+vi.mock("svelte/server", () => ({
+  render: vi.fn(),
+}));
+
+const mockRender = vi.mocked(render);
+
+/**
+ * Registers a custom element + renderer pair under a fresh tag name, so each
+ * test is independent of the process-global custom element registry.
+ */
+let tagCounter = 0;
+const registerElement = (options: { prepare?: () => void | Promise<void> }) => {
+  const tagName = `test-element-${++tagCounter}`;
+
+  class ClientElement {
+    attributes: Record<string, string> = {};
+    attributeChangedCallback = vi.fn();
+    $$d: Record<string, unknown> = {};
+    $$p_d: Record<string, never> = {};
+    $$c = {} as never;
+  }
+
+  class Renderer extends SvelteCustomElementRenderer {
+    constructor(tag: string) {
+      super(
+        {} as never,
+        ClientElement as never,
+        tag,
+        undefined,
+        options.prepare,
+      );
+    }
+  }
+
+  // the shim's registry needs a real constructor to hand back to lookups
+  class HostElement extends globalThis.HTMLElement {}
+  customElements.define(tagName, HostElement);
+  ElementRendererRegistry.set(tagName, Renderer as never);
+
+  return tagName;
+};
+
+describe("renderCustomElement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRender.mockReturnValue({
+      head: "",
+      body: "<p>hello</p>",
+    } as unknown as ReturnType<typeof render>);
+  });
+
+  test("wraps shadow output in a declarative shadow root template", () => {
+    const tagName = registerElement({});
+
+    const { shadowTemplate } = renderCustomElementSync(tagName, {});
+
+    expect(shadowTemplate).toBe(
+      '<template shadowrootmode="open"><p>hello</p></template>',
+    );
+  });
+
+  test("routes string props with kebab-case names to attributes", () => {
+    const tagName = registerElement({});
+
+    const { attributes } = renderCustomElementSync(tagName, {
+      "data-label": "hi",
+    });
+
+    expect(attributes).toEqual({ "data-label": "hi" });
+  });
+
+  test("routes non-string and camelCase props to properties", () => {
+    const tagName = registerElement({});
+
+    const { attributes } = renderCustomElementSync(tagName, {
+      count: 5,
+      userName: "ada",
+    });
+
+    // properties do not reflect to attributes without a prop definition
+    expect(attributes).toEqual({});
+    expect(mockRender).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        props: expect.objectContaining({ count: 5, userName: "ada" }),
+      }),
+    );
+  });
+
+  test("does not forward host wrapper plumbing props to the element", () => {
+    const tagName = registerElement({});
+
+    renderCustomElementSync(tagName, {
+      _tagName: "should-not-leak",
+      children: "should-not-leak",
+      real: 1,
+    });
+
+    const renderOptions = mockRender.mock.calls[0]?.[1] as
+      { props?: Record<string, unknown> } | undefined;
+    expect(renderOptions?.props).toEqual({ real: 1 });
+  });
+
+  test("rejects an invalid custom element tag name", () => {
+    expect(() => renderCustomElementSync("notcustom", {})).toThrow(
+      /Invalid custom element tag name/,
+    );
+  });
+
+  test("reports an unregistered element rather than rendering nothing", () => {
+    class Unregistered extends globalThis.HTMLElement {}
+    customElements.define("unregistered-element", Unregistered);
+
+    expect(() => renderCustomElementSync("unregistered-element", {})).toThrow(
+      /renderer for unregistered-element not found/i,
+    );
+  });
+
+  test("throws from the sync path when the renderer is asynchronous", () => {
+    const tagName = registerElement({
+      prepare: () => Promise.resolve(),
+    });
+
+    // an async SsrPrepare hook makes the shadow stream yield a promise, which
+    // the synchronous collector cannot consume
+    expect(() => renderCustomElementSync(tagName, {})).toThrow();
+  });
+
+  test("awaits an asynchronous renderer on the async path", async () => {
+    const tagName = registerElement({
+      prepare: () => Promise.resolve(),
+    });
+
+    const { shadowTemplate } = await renderCustomElement(tagName, {});
+
+    expect(shadowTemplate).toBe(
+      '<template shadowrootmode="open"><p>hello</p></template>',
+    );
+  });
+
+  test("accepts a synchronous renderer on the async path too", async () => {
+    const tagName = registerElement({});
+
+    const { shadowTemplate } = await renderCustomElement(tagName, {});
+
+    expect(shadowTemplate).toBe(
+      '<template shadowrootmode="open"><p>hello</p></template>',
+    );
+  });
+});

--- a/packages/ssr/src/lib/runtime/renderCustomElement.ts
+++ b/packages/ssr/src/lib/runtime/renderCustomElement.ts
@@ -1,0 +1,130 @@
+import {
+  collectResult,
+  collectResultSync,
+} from "@lit-labs/ssr/lib/render-result.js";
+import { isKebabCase, camelizeKebabCase } from "@svebcomponents/utils";
+
+import { isValidCustomElementTagName } from "./html.js";
+import { ElementRendererRegistry } from "./rendererRegistry.js";
+import { isSvelteCustomElementRenderer } from "./svelteCustomElementRenderer.js";
+
+/**
+ * The host-framework-neutral result of server-rendering one custom element.
+ *
+ * A host integration emits these two pieces around its own children:
+ * the attributes go on the custom element tag, and `shadowTemplate` is
+ * inserted as the element's *first* child so the HTML parser adopts it into
+ * a shadow root before hydration runs.
+ */
+export interface RenderedCustomElement {
+  /**
+   * Host attributes as a raw name→value record. Values are unescaped — the
+   * host framework's own attribute serialization is expected to escape them.
+   */
+  attributes: Record<string, string>;
+  /**
+   * A complete `<template shadowrootmode="open">…</template>` string. Its
+   * content is already escaped by the element renderer.
+   */
+  shadowTemplate: string;
+}
+
+/**
+ * Props a host wrapper uses for its own plumbing rather than passing to the
+ * custom element. Excluded defensively: every current wrapper already strips
+ * these before calling, but a wrapper that forwards a raw prop bag should not
+ * be able to leak them into the rendered element.
+ */
+const RESERVED_PROP_NAMES = new Set(["_tagName", "children"]);
+
+/**
+ * Looks up the registered renderer for `tagName`, applies `props` to it, and
+ * returns it alongside its shadow `RenderResult` stream.
+ *
+ * Whether that stream can be collected synchronously depends on the
+ * component: a renderer whose `SsrPrepare` hook returns a promise, or whose
+ * component genuinely awaits while rendering, yields promises into the
+ * stream and therefore requires {@link renderCustomElement}.
+ */
+const startRender = (tagName: string, props: Record<string, unknown>) => {
+  if (!isValidCustomElementTagName(tagName)) {
+    throw new Error(`Invalid custom element tag name: ${tagName}`);
+  }
+
+  const ctor = customElements.get(tagName);
+  if (!ctor) throw new Error(`Custom element ${tagName} not found`);
+
+  const CustomElementRendererCtor = ElementRendererRegistry.get(ctor);
+  if (!CustomElementRendererCtor)
+    throw new Error(`Custom element renderer for ${tagName} not found`);
+  const renderer = new CustomElementRendererCtor(tagName);
+  if (!isSvelteCustomElementRenderer(renderer)) {
+    throw new Error(
+      `Renderer for ${tagName} must extend SvelteCustomElementRenderer`,
+    );
+  }
+
+  for (const [key, value] of Object.entries(props)) {
+    if (RESERVED_PROP_NAMES.has(key)) continue;
+    if (typeof value === "string" && isKebabCase(key)) {
+      renderer.setAttribute(key, value);
+      continue;
+    }
+    if (isKebabCase(key)) {
+      renderer.setProperty(camelizeKebabCase(key), value);
+      continue;
+    }
+    renderer.setProperty(key, value);
+  }
+
+  const shadowStream = renderer.renderShadow(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: pass something meaningful here
+    {} as any,
+  );
+  if (!shadowStream) throw new Error(`Shadow stream for ${tagName} not found`);
+
+  return { renderer, shadowStream };
+};
+
+const wrapShadow = (shadow: string) =>
+  `<template shadowrootmode="open">${shadow}</template>`;
+
+/**
+ * Server-renders a custom element, collecting its shadow content
+ * synchronously.
+ *
+ * Throws if the component renders asynchronously (an async `SsrPrepare` hook,
+ * or a component that awaits while rendering). Host integrations that can
+ * await should use {@link renderCustomElement} instead; ones that cannot
+ * should treat the throw as a signal to fall back to client-only rendering.
+ */
+export const renderCustomElementSync = (
+  tagName: string,
+  props: Record<string, unknown>,
+): RenderedCustomElement => {
+  const { renderer, shadowStream } = startRender(tagName, props);
+  const shadow = collectResultSync(shadowStream);
+  return {
+    attributes: renderer.getSsrAttributes(),
+    shadowTemplate: wrapShadow(shadow),
+  };
+};
+
+/**
+ * Server-renders a custom element, awaiting asynchronous shadow content.
+ *
+ * Accepts both synchronous and asynchronous renderers, so host integrations
+ * whose SSR pipeline can await (Vue's `renderToString`, for instance) should
+ * prefer this over {@link renderCustomElementSync}.
+ */
+export const renderCustomElement = async (
+  tagName: string,
+  props: Record<string, unknown>,
+): Promise<RenderedCustomElement> => {
+  const { renderer, shadowStream } = startRender(tagName, props);
+  const shadow = await collectResult(shadowStream);
+  return {
+    attributes: renderer.getSsrAttributes(),
+    shadowTemplate: wrapShadow(shadow),
+  };
+};

--- a/packages/ssr/src/lib/vite/AsyncServer.svelte
+++ b/packages/ssr/src/lib/vite/AsyncServer.svelte
@@ -7,12 +7,8 @@
   // are idempotent, so this is safe to run alongside that too.
   import "../runtime/installShim.js";
   import type { Snippet } from "svelte";
-  import { isKebabCase, camelizeKebabCase } from "@svebcomponents/utils";
-  import { collectResult } from "@lit-labs/ssr/lib/render-result.js";
 
-  import { isValidCustomElementTagName } from "../runtime/html.js";
-  import { ElementRendererRegistry } from "../runtime/rendererRegistry.js";
-  import { isSvelteCustomElementRenderer } from "../runtime/svelteCustomElementRenderer.js";
+  import { renderCustomElement } from "../runtime/renderCustomElement.js";
 
   interface WebComponentWrapperProps {
     children?: Snippet;
@@ -26,56 +22,6 @@
     ...props
   }: WebComponentWrapperProps = $props();
 
-  const renderCustomElement = async (
-    tagName: string,
-    customElementProps: Record<string, unknown>,
-  ) => {
-    if (!isValidCustomElementTagName(tagName)) {
-      throw new Error(`Invalid custom element tag name: ${tagName}`);
-    }
-
-    const ctor = customElements.get(tagName);
-    if (!ctor) throw new Error(`Custom element ${tagName} not found`);
-
-    const CustomElementRendererCtor = ElementRendererRegistry.get(ctor);
-    if (!CustomElementRendererCtor)
-      throw new Error(`Custom element renderer for ${tagName} not found`);
-    const customElementRenderer = new CustomElementRendererCtor(tagName);
-    if (!isSvelteCustomElementRenderer(customElementRenderer)) {
-      throw new Error(
-        `Renderer for ${tagName} must extend SvelteCustomElementRenderer`,
-      );
-    }
-
-    for (const [key, value] of Object.entries(customElementProps)) {
-      if (key === "_tagName" || key === "children") continue;
-      if (typeof value === "string" && isKebabCase(key)) {
-        customElementRenderer.setAttribute(key, value);
-        continue;
-      }
-      if (isKebabCase(key)) {
-        customElementRenderer.setProperty(camelizeKebabCase(key), value);
-        continue;
-      }
-      customElementRenderer.setProperty(key, value);
-    }
-
-    const shadowStream = customElementRenderer.renderShadow(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: pass something meaningful here
-      {} as any,
-    );
-    if (!shadowStream)
-      throw new Error(`Shadow stream for ${tagName} not found`);
-    const shadow = await collectResult(shadowStream);
-    return {
-      attributes: customElementRenderer.getSsrAttributes(),
-      // The parser consumes this template into the element's shadow root
-      // before hydration runs, leaving an empty {@html} anchor pair behind —
-      // which is exactly what Client.svelte's `{@html ""}` claims.
-      shadowTemplate: `<template shadowrootmode="open">${shadow}</template>`,
-    };
-  };
-
   // svelte-ignore state_referenced_locally -- SSR renders this wrapper once from the initial custom-element props.
   const rendered = renderCustomElement(tag, props);
 </script>
@@ -83,7 +29,10 @@
 <!-- The element fragment below must stay structurally identical to
 Client.svelte's (and Server.svelte's): rendering the same svelte constructs
 on both sides is what lets a hydrating Svelte host claim the SSR'd custom
-element instead of re-creating it. -->
+element instead of re-creating it.
+The parser consumes the shadow template into the element's shadow root
+before hydration runs, leaving an empty {@html} anchor pair behind — which
+is exactly what Client.svelte's `{@html ""}` claims. -->
 <!-- eslint-disable svelte/no-at-html-tags -- shadow content is escaped by the element renderer -->
 <svelte:element this={tag} {...(await rendered).attributes}
   >{@html (await rendered).shadowTemplate}{@render children?.()}</svelte:element

--- a/packages/ssr/src/lib/vite/Server.svelte
+++ b/packages/ssr/src/lib/vite/Server.svelte
@@ -7,12 +7,8 @@
   // are idempotent, so this is safe to run alongside that too.
   import "../runtime/installShim.js";
   import type { Snippet } from "svelte";
-  import { isKebabCase, camelizeKebabCase } from "@svebcomponents/utils";
-  import { collectResultSync } from "@lit-labs/ssr/lib/render-result.js";
 
-  import { isValidCustomElementTagName } from "../runtime/html.js";
-  import { ElementRendererRegistry } from "../runtime/rendererRegistry.js";
-  import { isSvelteCustomElementRenderer } from "../runtime/svelteCustomElementRenderer.js";
+  import { renderCustomElementSync } from "../runtime/renderCustomElement.js";
 
   interface WebComponentWrapperProps {
     children?: Snippet;
@@ -26,65 +22,18 @@
     ...props
   }: WebComponentWrapperProps = $props();
 
-  const renderCustomElement = (
-    tagName: string,
-    customElementProps: Record<string, unknown>,
-  ) => {
-    if (!isValidCustomElementTagName(tagName)) {
-      throw new Error(`Invalid custom element tag name: ${tagName}`);
-    }
-
-    const ctor = customElements.get(tagName);
-    if (!ctor) throw new Error(`Custom element ${tagName} not found`);
-
-    const CustomElementRendererCtor = ElementRendererRegistry.get(ctor);
-    if (!CustomElementRendererCtor)
-      throw new Error(`Custom element renderer for ${tagName} not found`);
-    const customElementRenderer = new CustomElementRendererCtor(tagName);
-    if (!isSvelteCustomElementRenderer(customElementRenderer)) {
-      throw new Error(
-        `Renderer for ${tagName} must extend SvelteCustomElementRenderer`,
-      );
-    }
-
-    for (const [key, value] of Object.entries(customElementProps)) {
-      if (key === "_tagName" || key === "children") continue;
-      if (typeof value === "string" && isKebabCase(key)) {
-        customElementRenderer.setAttribute(key, value);
-        continue;
-      }
-      if (isKebabCase(key)) {
-        customElementRenderer.setProperty(camelizeKebabCase(key), value);
-        continue;
-      }
-      customElementRenderer.setProperty(key, value);
-    }
-
-    const shadowStream = customElementRenderer.renderShadow(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: pass something meaningful here
-      {} as any,
-    );
-    if (!shadowStream)
-      throw new Error(`Shadow stream for ${tagName} not found`);
-    const shadow = collectResultSync(shadowStream);
-    return {
-      attributes: customElementRenderer.getSsrAttributes(),
-      // The parser consumes this template into the element's shadow root
-      // before hydration runs, leaving an empty {@html} anchor pair behind —
-      // which is exactly what Client.svelte's `{@html ""}` claims.
-      shadowTemplate: `<template shadowrootmode="open">${shadow}</template>`,
-    };
-  };
-
   // eslint-disable-next-line svelte/no-unused-svelte-ignore -- svelte-check reports this warning, but eslint does not.
   // svelte-ignore state_referenced_locally -- SSR renders this wrapper once from the initial custom-element props.
-  const rendered = renderCustomElement(tag, props);
+  const rendered = renderCustomElementSync(tag, props);
 </script>
 
 <!-- The element fragment below must stay structurally identical to
 Client.svelte's (and AsyncServer.svelte's): rendering the same svelte
 constructs on both sides is what lets a hydrating Svelte host claim the
-SSR'd custom element instead of re-creating it. -->
+SSR'd custom element instead of re-creating it.
+The parser consumes the shadow template into the element's shadow root
+before hydration runs, leaving an empty {@html} anchor pair behind — which
+is exactly what Client.svelte's `{@html ""}` claims. -->
 <!-- eslint-disable svelte/no-at-html-tags -- shadow content is escaped by the element renderer -->
 <svelte:element this={tag} {...rendered.attributes}
   >{@html rendered.shadowTemplate}{@render children?.()}</svelte:element


### PR DESCRIPTION
**PR 1 of 4** in a stack exploring Vue/React renderer integrations.

## What

`Server.svelte` and `AsyncServer.svelte` each carried an identical copy of the custom-element render logic — resolve the tag, look up the registered `ElementRenderer`, split incoming props into attributes vs properties, and collect the shadow `RenderResult` into a declarative shadow root template. The only difference between the two was `collectResultSync` vs `collectResult`.

This moves that into `packages/ssr/src/lib/runtime/renderCustomElement.ts`, exporting:

```ts
renderCustomElementSync(tag, props): RenderedCustomElement
renderCustomElement(tag, props): Promise<RenderedCustomElement>
```

Both return `{ attributes, shadowTemplate }`. The Svelte wrappers keep their own element fragments — that markup is the part that genuinely differs per host framework, and the hydration-claim contract between `Server`/`AsyncServer`/`Client` is unchanged.

## Why

De-duplicating two verbatim copies is worth doing on its own, but the real motivation is that this is the seam every non-Svelte host integration hangs off. The rest of the SSR runtime — `installShim`, `ElementRendererRegistry`, `SvelteCustomElementRenderer`, the tsdown build side, `hydratable` — is already host-framework agnostic. This was the last piece of genuinely reusable logic trapped inside a `.svelte` file.

## Notes

- `RESERVED_PROP_NAMES` keeps the defensive `_tagName`/`children` skip from the original wrappers. Both are already destructured out before the call today, but every host wrapper has plumbing props of its own, so the guard belongs in the core.
- The order of `collectResult*` before `getSsrAttributes()` is preserved deliberately: an `SsrPrepare` hook can `setProperty`, which may reflect to a host attribute, so attributes must be read after the shadow render completes.
- Added `renderCustomElement.test.ts` (9 tests). One of them pins the failure mode that motivates the rest of the stack: an async renderer hitting the sync path throws rather than degrading, which is the behavior a non-awaiting host integration will need to catch and fall back on.

## Testing

- `packages/ssr`: 122 passed (113 before, +9 new)
- `e2e/ssr`: 15 passed, including the browser hydration fixture
- `svelte-check` clean, eslint + prettier clean

No behavior change for Svelte hosts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fuo3px5zhRHpmxeij88APf)_