### PR TITLE
docs(ssr): give asynchronous rendering one canonical explanation

### DIFF
--- a/apps/docs/src/content/docs/core-concepts/build.mdx
+++ b/apps/docs/src/content/docs/core-concepts/build.mdx
@@ -171,9 +171,13 @@ The browser export defines the custom element. The matching SSR export
 provides the renderer that a server application can register.
 
 An SSR component can add an adjacent `ColorPicker.ssr.ts` (or `.js`)
-preparation hook next to `ColorPicker.svelte`. The hook is compiled only into the server output;
-see the [build package reference](/packages/build/#server-preparation) for its
-`SsrPrepare` signature and hydration behavior.
+preparation hook next to `ColorPicker.svelte`, letting the component acquire its
+own data on the server. The hook is compiled only into the server output. See the
+[build package reference](/packages/build/#server-preparation) for its
+`SsrPrepare` signature, and
+[What makes a component asynchronous](/core-concepts/ssr/#what-makes-a-component-asynchronous)
+for when a hook puts the component on the async path and why it is preferable to
+awaiting in the component.
 
 SSR is currently in beta. See [SSR](/core-concepts/ssr/) for its stability and
 security considerations.

--- a/apps/docs/src/content/docs/core-concepts/ssr/framework-integrations.mdx
+++ b/apps/docs/src/content/docs/core-concepts/ssr/framework-integrations.mdx
@@ -103,8 +103,9 @@ Then write custom elements in any single-file component:
 
 Vue's `renderToString` fully awaits an async `setup()` and emits its output in
 order, so one wrapper handles both synchronous and asynchronous element
-renderers. Nothing extra is needed for a component that awaits while rendering
-or that has an async `SsrPrepare` hook — beyond the
+renderers. An
+[asynchronous component](/core-concepts/ssr/#what-makes-a-component-asynchronous)
+needs nothing extra here beyond the
 [`enable-async` opt-in](/core-concepts/ssr/#async-rendering-outside-svelte)
 every non-Svelte host needs.
 
@@ -154,9 +155,9 @@ import { CustomElement } from "@svebcomponents/ssr-react";
 
 ### Synchronous by default, with an RSC opt-in
 
-React's `renderToString` cannot await, so a component that performs
-asynchronous work — one that awaits while rendering, or that has an async
-`SsrPrepare` hook — cannot be server-rendered by the default `CustomElement`.
+React's `renderToString` cannot await, so an
+[asynchronous component](/core-concepts/ssr/#what-makes-a-component-asynchronous)
+cannot be server-rendered by the default `CustomElement`.
 
 Rather than failing the page, such an element is emitted without
 server-rendered shadow content and rendered in the browser only, with a
@@ -174,8 +175,9 @@ import { CustomElement } from "@svebcomponents/ssr-react/rsc";
 
 An RSC async function component runs to completion before any markup is
 emitted, so it can simply `await` the renderer — no cache, no `use()`, no
-Suspense boundary required, and it accepts asynchronous `SsrPrepare` hooks and
-components that await while rendering (given the
+Suspense boundary required, and it accepts
+[asynchronous components](/core-concepts/ssr/#what-makes-a-component-asynchronous)
+in either form (given the
 [`enable-async` opt-in](/core-concepts/ssr/#async-rendering-outside-svelte)
 every non-Svelte host needs for that).
 
@@ -219,7 +221,9 @@ applies there instead.
 ### No async split either
 
 Astro frontmatter is an async module scope, so the wrapper awaits the element
-renderer directly — asynchronous components need nothing extra beyond the
+renderer directly —
+[asynchronous components](/core-concepts/ssr/#what-makes-a-component-asynchronous)
+need nothing extra beyond the
 [`enable-async` opt-in](/core-concepts/ssr/#async-rendering-outside-svelte)
 every non-Svelte host needs.
 

--- a/apps/docs/src/content/docs/core-concepts/ssr/index.mdx
+++ b/apps/docs/src/content/docs/core-concepts/ssr/index.mdx
@@ -141,6 +141,44 @@ render(html`<my-component title="Hello"></my-component>`, {
 
 Both directions are covered by end-to-end tests in the repository.
 
+## What Makes a Component Asynchronous
+
+Whether an element renders synchronously decides which host integrations can
+server-render it, so it is worth being precise about what puts a component on
+the async path. There are exactly two ways:
+
+1. **The component awaits while rendering** — an `await` in its instance
+   script, or anywhere Svelte's `experimental.async` allows one.
+2. **Its preparation hook returns a promise** — the adjacent
+   `<entry>.ssr.ts` module described in
+   [Server preparation](/core-concepts/build/#optional-ssr-output), whose
+   default-exported `SsrPrepare` function may return a promise.
+
+Everything else renders synchronously, including a hook that returns nothing.
+A hook that bails out early — because the host already supplied the value it
+would have fetched — therefore keeps the synchronous path available, which is
+what makes the second form safe to add to a component that hosts may render
+either way.
+
+### Why a preparation hook rather than just awaiting
+
+The two are not interchangeable, and the hook exists for the cases awaiting
+cannot cover:
+
+- **Server-only dependencies stay off the client.** `<entry>.ssr.ts` is
+  compiled into the server output only. A database client, an API SDK or a
+  secret-bearing module used there never enters the browser bundle. An `await`
+  in the component puts that code in both.
+- **The result survives hydration.** Properties set through the hook's
+  `setProperty` join rich-property serialization, so the client adopts the
+  prepared value instead of fetching it again. A value awaited inside the
+  component is local state — it is not serialized, and the browser repeats the
+  work.
+
+Awaiting in the component is the right tool when the asynchrony is part of
+rendering. The hook is the right tool when the component owns acquiring its
+own data.
+
 ## Async Rendering Outside Svelte
 
 Svelte gates asynchronous server rendering behind a module-global flag, which

--- a/packages/ssr-astro/README.md
+++ b/packages/ssr-astro/README.md
@@ -55,10 +55,11 @@ svebcomponents integration applies there.
 ## Async Components
 
 Astro frontmatter is an async module scope, so the wrapper simply awaits the
-element renderer. A component that awaits while rendering, or that has an
-async `SsrPrepare` hook, works through the same wrapper as a synchronous one —
-no sync/async split as in the Svelte integration, and no degradation as in
-React's.
+element renderer. An asynchronous component — one that awaits while rendering,
+or whose `<entry>.ssr.ts` preparation hook returns a promise (see
+[What makes a component asynchronous](https://svebcomponents.dev/core-concepts/ssr/#what-makes-a-component-asynchronous))
+— works through the same wrapper as a synchronous one: no sync/async split as in
+the Svelte integration, and no degradation as in React's.
 
 Being a non-Svelte host, an Astro app does need to opt into Svelte's async SSR
 mode explicitly:

--- a/packages/ssr-react/README.md
+++ b/packages/ssr-react/README.md
@@ -78,10 +78,11 @@ import { CustomElement } from "@svebcomponents/ssr-react";
 
 ## Async Components
 
-React's `renderToString` cannot await, so a component that renders
-asynchronously — one that awaits while rendering, or whose `index.ssr.ts`
-exports an async `SsrPrepare` hook — **cannot be server-rendered by the
-default `CustomElement`**.
+React's `renderToString` cannot await, so an asynchronous component **cannot be
+server-rendered by the default `CustomElement`**. A component is asynchronous if
+it awaits while rendering, or if its `<entry>.ssr.ts` preparation hook returns a
+promise — see
+[What makes a component asynchronous](https://svebcomponents.dev/core-concepts/ssr/#what-makes-a-component-asynchronous).
 
 Rather than failing the page, such an element is emitted without server-rendered
 shadow content and rendered in the browser only, with a one-time console

--- a/packages/ssr-vue/README.md
+++ b/packages/ssr-vue/README.md
@@ -69,10 +69,11 @@ that honest.
 ## Async Components
 
 Unlike the Svelte integration, there is no sync/async wrapper split. Vue's
-`renderToString` fully awaits an async `setup()` and emits its output in
-order, so a component that awaits while rendering — or whose `index.ssr.ts`
-exports an async `SsrPrepare` hook — renders through the same wrapper a
-synchronous one does.
+`renderToString` fully awaits an async `setup()` and emits its output in order,
+so an asynchronous component renders through the same wrapper a synchronous one
+does. A component is asynchronous if it awaits while rendering, or if its
+`<entry>.ssr.ts` preparation hook returns a promise — see
+[What makes a component asynchronous](https://svebcomponents.dev/core-concepts/ssr/#what-makes-a-component-asynchronous).
 
 There is one catch, and it applies to any non-Svelte host. Svelte gates async
 SSR behind a module-global flag that is normally flipped by a Svelte app

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -57,7 +57,9 @@ When using `@svebcomponents/build`, an adjacent server module such as
 `src/index.ssr.ts` is discovered automatically. Its default `SsrPrepare` export
 runs after host attributes and properties have been applied but before the
 component renders. Values written with `setProperty` are serialized into
-hydratable output for reuse in the browser.
+hydratable output for reuse in the browser. Returning a promise puts the
+component on the async path — see
+[What makes a component asynchronous](https://svebcomponents.dev/core-concepts/ssr/#what-makes-a-component-asynchronous).
 
 If the package's Svelte config enables Svelte async rendering, the generated
 `./ssr` renderer can yield async Lit `RenderResult` chunks. Async-capable host


### PR DESCRIPTION
> **Stacked on #146**, same as #147 was. Base is `codex/direct-svelte-entries`,
> so this is one commit on top of the merged audit work.

## What changed

Four READMEs, the framework-integrations page and the build docs each restated
the same rule — *"a component that awaits while rendering, or whose
`index.ssr.ts` exports an async `SsrPrepare` hook"* — while nothing anywhere
explained **why both forms exist**. The rule had no canonical home, which is
what made the `.ssr.ts` hook read as a redundant second path to asynchrony
rather than a distinct capability.

Adds **What Makes a Component Asynchronous** to the SSR concept page:

- the two forms, stated once
- that a hook returning nothing keeps the synchronous path available — which is
  what makes it safe to add to a component hosts may render either way
- a subsection on why the hook is *not* interchangeable with awaiting:
  - `<entry>.ssr.ts` is compiled into the server output only, so server-only
    dependencies (a database client, an API SDK, a secret-bearing module) never
    enter the browser bundle — an `await` in the component puts that code in both
  - properties set through `setProperty` join rich-property serialization, so the
    client adopts the prepared value; a value awaited inside the component is
    local state, is not serialized, and the browser repeats the work

Every restatement now links to it.

## Why

This came out of a question about whether the `.ssr.ts` concept was still
necessary at all, or a leftover from another project. It isn't a leftover — but
the docs gave no way to reach that conclusion, which is a documentation bug
worth fixing before beta. Two supporting facts, both checked:

- async Svelte SSR landed in #66 (Jul 6); the prepare hook landed in #114
  (Jul 22), *after* it — so the hook was never a pre-async workaround
- `svebcomponents/atproto` uses a live hook in
  `components/atproto-comments/src/index.ssr.ts` to self-fetch its comment
  thread during SSR, and its architecture doc names both properties above as the
  reason

## Impact

Documentation only; no behavior change and no changeset. All four affected
packages (`ssr` at minor, the three integrations at patch) are already bumping
this release cycle, so the revised READMEs ship with them.

The published integration READMEs keep a one-line summary *before* the link
rather than linking only — they are read on npm, where a bare cross-reference
isn't enough to act on. The docs pages, which sit next to the canonical section,
link without restating.

## Validation

- `pnpm check` — 22 tasks, including `astro check` over the docs site
- `pnpm lint` — 21 tasks
- `pnpm build` — 13 tasks
- Every anchor verified against the headings it targets:
  `#what-makes-a-component-asynchronous`,
  `#async-rendering-outside-svelte`, `#optional-ssr-output`,
  `#server-preparation`


---
_Generated by [Claude Code](https://claude.ai/code/session_018iU1iyHJWb21MRSNKziYS7)_